### PR TITLE
feat: complaint management — raise, view, resolve, reject with images and notifications

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
+    "cloudinary": "^2.9.0",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",
     "prisma": "^5.22.0"

--- a/apps/api/prisma/migrations/20260409151543_add_complaints/migration.sql
+++ b/apps/api/prisma/migrations/20260409151543_add_complaints/migration.sql
@@ -1,0 +1,67 @@
+-- CreateEnum
+CREATE TYPE "ComplaintCategory" AS ENUM ('WATER_SUPPLY', 'ELECTRICITY', 'LIFT_ELEVATOR', 'GENERATOR', 'INTERNET_CABLE', 'PARKING', 'GARBAGE_WASTE', 'GARDEN_LANDSCAPING', 'GYM_CLUBHOUSE', 'SWIMMING_POOL', 'SECURITY', 'NOISE', 'PET_RELATED', 'DOMESTIC_HELP', 'NEIGHBOUR_BEHAVIOUR', 'STAFF_BEHAVIOUR', 'MAINTENANCE_REPAIR', 'RULE_VIOLATION', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "ComplaintVisibility" AS ENUM ('PUBLIC', 'PRIVATE');
+
+-- CreateEnum
+CREATE TYPE "ComplaintStatus" AS ENUM ('OPEN', 'RESOLVED', 'REJECTED');
+
+-- CreateTable
+CREATE TABLE "complaints" (
+    "id" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "raisedBy" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "category" "ComplaintCategory" NOT NULL,
+    "visibility" "ComplaintVisibility" NOT NULL DEFAULT 'PRIVATE',
+    "status" "ComplaintStatus" NOT NULL DEFAULT 'OPEN',
+    "rejectionReason" TEXT,
+    "resolvedAt" TIMESTAMP(3),
+    "resolvedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "complaints_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "complaint_images" (
+    "id" TEXT NOT NULL,
+    "complaintId" TEXT NOT NULL,
+    "imageUrl" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "complaint_images_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "complaints_orgId_idx" ON "complaints"("orgId");
+
+-- CreateIndex
+CREATE INDEX "complaints_raisedBy_idx" ON "complaints"("raisedBy");
+
+-- CreateIndex
+CREATE INDEX "complaints_orgId_status_idx" ON "complaints"("orgId", "status");
+
+-- CreateIndex
+CREATE INDEX "complaints_orgId_visibility_idx" ON "complaints"("orgId", "visibility");
+
+-- CreateIndex
+CREATE INDEX "complaints_orgId_category_idx" ON "complaints"("orgId", "category");
+
+-- CreateIndex
+CREATE INDEX "complaint_images_complaintId_idx" ON "complaint_images"("complaintId");
+
+-- AddForeignKey
+ALTER TABLE "complaints" ADD CONSTRAINT "complaints_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "complaints" ADD CONSTRAINT "complaints_raisedBy_fkey" FOREIGN KEY ("raisedBy") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "complaints" ADD CONSTRAINT "complaints_resolvedBy_fkey" FOREIGN KEY ("resolvedBy") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "complaint_images" ADD CONSTRAINT "complaint_images_complaintId_fkey" FOREIGN KEY ("complaintId") REFERENCES "complaints"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -27,6 +27,8 @@ model User {
   person        Person?
   memberships   Membership[]
   deviceTokens  DeviceToken[]
+  complaintsRaised   Complaint[] @relation("ComplaintRaiser")
+  complaintsResolved Complaint[] @relation("ComplaintResolver")
   
   @@map("users")
 }
@@ -70,6 +72,7 @@ model Organization {
   roles          Role[]
   auditLogs      AuditLog[]
   invitations    Invitation[]
+  complaints    Complaint[]
 
   @@map("organizations")
 }
@@ -304,4 +307,77 @@ model DeviceToken {
 enum Platform {
   IOS
   ANDROID
+}
+
+model Complaint {
+  id              String              @id @default(uuid())
+  orgId           String
+  raisedBy        String
+  title           String
+  description     String
+  category        ComplaintCategory
+  visibility      ComplaintVisibility @default(PRIVATE)
+  status          ComplaintStatus     @default(OPEN)
+  rejectionReason String?
+  resolvedAt      DateTime?
+  resolvedBy      String?
+  createdAt       DateTime            @default(now())
+  updatedAt       DateTime            @updatedAt
+
+  org             Organization        @relation(fields: [orgId], references: [id])
+  raiser          User                @relation("ComplaintRaiser", fields: [raisedBy], references: [id])
+  resolver        User?               @relation("ComplaintResolver", fields: [resolvedBy], references: [id])
+  images          ComplaintImage[]
+
+  @@index([orgId])
+  @@index([raisedBy])
+  @@index([orgId, status])
+  @@index([orgId, visibility])
+  @@index([orgId, category])
+  @@map("complaints")
+}
+
+model ComplaintImage {
+  id          String    @id @default(uuid())
+  complaintId String
+  imageUrl    String
+  createdAt   DateTime  @default(now())
+
+  complaint   Complaint @relation(fields: [complaintId], references: [id])
+
+  @@index([complaintId])
+  @@map("complaint_images")
+}
+
+enum ComplaintCategory {
+  WATER_SUPPLY
+  ELECTRICITY
+  LIFT_ELEVATOR
+  GENERATOR
+  INTERNET_CABLE
+  PARKING
+  GARBAGE_WASTE
+  GARDEN_LANDSCAPING
+  GYM_CLUBHOUSE
+  SWIMMING_POOL
+  SECURITY
+  NOISE
+  PET_RELATED
+  DOMESTIC_HELP
+  NEIGHBOUR_BEHAVIOUR
+  STAFF_BEHAVIOUR
+  MAINTENANCE_REPAIR
+  RULE_VIOLATION
+  OTHER
+}
+
+enum ComplaintVisibility {
+  PUBLIC
+  PRIVATE
+}
+
+enum ComplaintStatus {
+  OPEN
+  RESOLVED
+  REJECTED
 }

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -40,13 +40,6 @@ async function main() {
     { name: 'occupancy.remove', module: 'property', description: 'Remove unit occupancy' },
     { name: 'occupancy.view',   module: 'property', description: 'View occupancy records' },
 
-    // Complaints
-    { name: 'complaint.create',        module: 'complaints', description: 'Raise a complaint' },
-    { name: 'complaint.view_own',      module: 'complaints', description: 'View own complaints' },
-    { name: 'complaint.view_all',      module: 'complaints', description: 'View all society complaints' },
-    { name: 'complaint.update_status', module: 'complaints', description: 'Update complaint status' },
-    { name: 'complaint.broadcast',     module: 'complaints', description: 'Broadcast complaint to all residents' },
-
     // Announcements
     { name: 'announcement.create', module: 'announcements', description: 'Create announcements' },
     { name: 'announcement.view',   module: 'announcements', description: 'View announcements' },
@@ -85,6 +78,15 @@ async function main() {
 
     // Co-resident
     { name: 'co_resident.invite', module: 'co_resident', description: 'Invite a co-resident to your flat' },
+
+    // Complaint
+    { name: 'complaint.create',      module: 'complaints', description: 'Raise a complaint' },
+    { name: 'complaint.view_own',    module: 'complaints', description: 'View own complaints' },
+    { name: 'complaint.view_all',    module: 'complaints', description: 'View all complaints in society' },
+    { name: 'complaint.resolve_own', module: 'complaints', description: 'Resolve own complaint' },
+    { name: 'complaint.resolve_any', module: 'complaints', description: 'Resolve any complaint' },
+    { name: 'complaint.reject',      module: 'complaints', description: 'Reject a complaint with reason' },
+
   ]
 
   for (const p of permissions) {
@@ -102,17 +104,15 @@ async function main() {
     Builder: [
       'society.create', 'society.update', 'society.view',
       'node.create', 'node.update', 'node.delete', 'node.view',
-      'member.view', 'member.remove',
+      'member.view', 'member.remove', 'member.reactivate',
       'invitation.create', 'invitation.cancel', 'invitation.view',
       'ownership.assign', 'ownership.remove', 'ownership.view',
       'occupancy.assign', 'occupancy.remove', 'occupancy.view',
-      'complaint.create', 'complaint.view_all',
-      'complaint.update_status', 'complaint.broadcast',
+      'complaint.view_all', 'complaint.resolve_any', 'complaint.reject',
       'announcement.create', 'announcement.view',
       'visitor.view_live', 'visitor.view_emergency',
       'emergency.declare', 'emergency.view',
-      'role.create', 'role.assign', 'role.view',
-      'member.reactivate'
+      'role.create', 'role.assign', 'role.view'
     ],
 
     Admin: [
@@ -122,19 +122,19 @@ async function main() {
       'invitation.create', 'invitation.cancel', 'invitation.view',
       'ownership.assign', 'ownership.remove', 'ownership.view',
       'occupancy.assign', 'occupancy.remove', 'occupancy.view',
-      'complaint.view_all', 'complaint.update_status', 'complaint.broadcast',
       'announcement.create', 'announcement.view',
       'visitor.view_live', 'visitor.view_emergency',
       'service.create', 'service.view',
       'poll.create', 'poll.vote', 'poll.view',
       'emergency.declare', 'emergency.view',
       'asset.create', 'asset.book', 'asset.view', 'asset.manage_booking',
-      'role.create', 'role.assign', 'role.view'
+      'role.create', 'role.assign', 'role.view',
+      'complaint.view_all', 'complaint.resolve_any', 'complaint.reject'
     ],
 
     Resident: [
       'society.view',
-      'complaint.create', 'complaint.view_own',
+      'complaint.create', 'complaint.view_own', 'complaint.resolve_own',
       'announcement.view',
       'visitor.approve', 'visitor.view_own',
       'service.view', 'service.manage_personal',
@@ -146,7 +146,7 @@ async function main() {
 
     'Co-resident': [
       'society.view',
-      'complaint.create', 'complaint.view_own',
+      'complaint.create', 'complaint.view_own', 'complaint.resolve_own',
       'announcement.view',
       'visitor.approve', 'visitor.view_own',
       'service.view',

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,7 @@ import nodesRouter from './routes/nodes'
 import invitationsRouter from './routes/invitations'
 import membersRouter from './routes/members'
 import deviceTokensRouter from './routes/deviceTokens'
+import complaintsRouter from './routes/complaints'
 import { enforceTenantContext } from './middleware/tenantContext'
 import { errorHandler } from './middleware/error'
 import { apiRateLimit } from './middleware/rateLimit'
@@ -22,6 +23,7 @@ app.use('/api/societies', nodesRouter)
 app.use('/api/societies', invitationsRouter)
 app.use('/api/societies', membersRouter)
 app.use('/api/auth', deviceTokensRouter)
+app.use('/api/societies', complaintsRouter)
 
 app.use(errorHandler)
 

--- a/apps/api/src/routes/complaints.ts
+++ b/apps/api/src/routes/complaints.ts
@@ -1,0 +1,414 @@
+import { Router, Response } from 'express'
+import { prisma } from '../lib/prisma'
+import { authenticate, AuthRequest } from '../middleware/auth'
+import { requirePermission } from '../middleware/permission'
+import { enforceTenantContext } from '../middleware/tenantContext'
+import { sendSuccess, sendError, sendNotFound } from '../utils/response'
+import { uploadMultipleImages } from '../utils/cloudinary'
+import { sendPushNotification } from '../utils/notifications'
+
+const router = Router()
+
+// ─────────────────────────────────────────────
+// POST /api/societies/:id/complaints
+// Raise a new complaint
+// ─────────────────────────────────────────────
+router.post(
+  '/:id/complaints',
+  authenticate,
+  enforceTenantContext,
+  requirePermission('complaint.create'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId } = req.params
+      const { title, description, category, visibility, images } = req.body
+
+      if (!title || !description || !category) {
+        return sendError(res, 'missing_field', 400, {
+          field: !title ? 'title' : !description ? 'description' : 'category'
+        })
+      }
+
+      const validCategories = [
+        'WATER_SUPPLY', 'ELECTRICITY', 'LIFT_ELEVATOR', 'GENERATOR',
+        'INTERNET_CABLE', 'PARKING', 'GARBAGE_WASTE', 'GARDEN_LANDSCAPING',
+        'GYM_CLUBHOUSE', 'SWIMMING_POOL', 'SECURITY', 'NOISE', 'PET_RELATED',
+        'DOMESTIC_HELP', 'NEIGHBOUR_BEHAVIOUR', 'STAFF_BEHAVIOUR',
+        'MAINTENANCE_REPAIR', 'RULE_VIOLATION', 'OTHER'
+      ]
+
+      if (!validCategories.includes(category)) {
+        return sendError(res, 'invalid_category', 400)
+      }
+
+      if (visibility && !['PUBLIC', 'PRIVATE'].includes(visibility)) {
+        return sendError(res, 'invalid_visibility', 400)
+      }
+
+      if (images && images.length > 5) {
+        return sendError(res, 'too_many_images', 400, {
+          message: 'Maximum 5 images allowed'
+        })
+      }
+
+      // Upload images to Cloudinary if provided
+      let imageUrls: string[] = []
+      if (images && images.length > 0) {
+        try {
+          imageUrls = await uploadMultipleImages(images)
+        } catch (uploadError) {
+          return sendError(res, 'image_upload_failed', 400)
+        }
+      }
+
+      // Create complaint
+      const complaint = await prisma.complaint.create({
+        data: {
+          orgId,
+          raisedBy:   req.user!.userId,
+          title:      title.trim(),
+          description: description.trim(),
+          category,
+          visibility: visibility ?? 'PRIVATE',
+          images: {
+            create: imageUrls.map(url => ({ imageUrl: url }))
+          }
+        },
+        include: {
+          images: true
+        }
+      })
+
+      // Notify all admins and builders
+      const adminMembers = await prisma.membership.findMany({
+        where: {
+          orgId,
+          isActive: true,
+          role: {
+            name: { in: ['Builder', 'Admin'] }
+          }
+        },
+        select: { userId: true }
+      })
+
+      const raiser = await prisma.person.findFirst({
+        where: { userId: req.user!.userId }
+      })
+
+      const raiserName = raiser?.fullName || 'A resident'
+
+      for (const member of adminMembers) {
+        await sendPushNotification(
+          member.userId,
+          'New Complaint',
+          `${raiserName}: ${title}`
+        )
+      }
+
+      return sendSuccess(res, {
+        id:         complaint.id,
+        title:      complaint.title,
+        category:   complaint.category,
+        visibility: complaint.visibility,
+        status:     complaint.status,
+        imageCount: complaint.images.length,
+        createdAt:  complaint.createdAt
+      }, 201)
+
+    } catch (error) {
+      console.error('POST /complaints error:', error)
+      return sendError(res, 'server_error', 500)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// GET /api/societies/:id/complaints
+// List complaints
+// ─────────────────────────────────────────────
+router.get(
+  '/:id/complaints',
+  authenticate,
+  enforceTenantContext,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId } = req.params
+      const { status, category, page = '1', limit = '20' } = req.query
+
+      const permissions = req.user!.permissions
+      const canViewAll = permissions.includes('complaint.view_all')
+      const userId = req.user!.userId
+
+      const pageNum  = Math.max(1, parseInt(page as string))
+      const limitNum = Math.min(50, Math.max(1, parseInt(limit as string)))
+      const skip     = (pageNum - 1) * limitNum
+
+      // Build where clause
+      const where: any = { orgId }
+
+      if (status) {
+        const validStatuses = ['OPEN', 'RESOLVED', 'REJECTED']
+        if (!validStatuses.includes(status as string)) {
+          return sendError(res, 'invalid_status', 400)
+        }
+        where.status = status
+      }
+
+      if (category) {
+        where.category = category
+      }
+
+      if (!canViewAll) {
+        // Resident sees own + public from others
+        where.OR = [
+          { raisedBy: userId },
+          { visibility: 'PUBLIC' }
+        ]
+      }
+
+      const [complaints, total] = await Promise.all([
+        prisma.complaint.findMany({
+          where,
+          skip,
+          take: limitNum,
+          orderBy: { createdAt: 'desc' },
+          include: {
+            raiser: {
+              include: { person: true }
+            },
+            images: {
+              select: { id: true }
+            }
+          }
+        }),
+        prisma.complaint.count({ where })
+      ])
+
+      const formatted = complaints.map(c => ({
+        id:         c.id,
+        title:      c.title,
+        category:   c.category,
+        visibility: c.visibility,
+        status:     c.status,
+        raisedBy:   canViewAll || c.raisedBy === userId
+          ? c.raiser.person?.fullName ?? 'Unknown'
+          : null,
+        raisedByMe: c.raisedBy === userId,
+        imageCount: c.images.length,
+        createdAt:  c.createdAt
+      }))
+
+      return sendSuccess(res, {
+        complaints: formatted,
+        total,
+        page:  pageNum,
+        pages: Math.ceil(total / limitNum)
+      })
+
+    } catch (error) {
+      console.error('GET /complaints error:', error)
+      return sendError(res, 'server_error', 500)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// GET /api/societies/:id/complaints/:complaintId
+// Complaint detail
+// ─────────────────────────────────────────────
+router.get(
+  '/:id/complaints/:complaintId',
+  authenticate,
+  enforceTenantContext,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId, complaintId } = req.params
+      const permissions = req.user!.permissions
+      const canViewAll  = permissions.includes('complaint.view_all')
+      const userId      = req.user!.userId
+
+      const complaint = await prisma.complaint.findFirst({
+        where: { id: complaintId, orgId },
+        include: {
+          raiser: {
+            include: { person: true }
+          },
+          resolver: {
+            include: { person: true }
+          },
+          images: true
+        }
+      })
+
+      if (!complaint) {
+        return sendNotFound(res, 'complaint_not_found')
+      }
+
+      // Resident can only see own or public complaints
+      if (!canViewAll) {
+        if (complaint.raisedBy !== userId && complaint.visibility === 'PRIVATE') {
+          return sendNotFound(res, 'complaint_not_found')
+        }
+      }
+
+      const isOwn = complaint.raisedBy === userId
+
+      return sendSuccess(res, {
+        id:              complaint.id,
+        title:           complaint.title,
+        description:     complaint.description,
+        category:        complaint.category,
+        visibility:      complaint.visibility,
+        status:          complaint.status,
+        rejectionReason: complaint.rejectionReason,
+        raisedBy:        canViewAll || isOwn ? {
+          name:  complaint.raiser.person?.fullName ?? 'Unknown',
+          phone: complaint.raiser.phone
+        } : null,
+        resolvedBy:   complaint.resolver?.person?.fullName ?? null,
+        resolvedAt:   complaint.resolvedAt,
+        images:       complaint.images.map(img => ({
+          id:       img.id,
+          imageUrl: img.imageUrl
+        })),
+        createdAt: complaint.createdAt,
+        updatedAt: complaint.updatedAt
+      })
+
+    } catch (error) {
+      console.error('GET /complaints/:id error:', error)
+      return sendError(res, 'server_error', 500)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// PATCH /api/societies/:id/complaints/:complaintId
+// Update complaint status
+// ─────────────────────────────────────────────
+router.patch(
+  '/:id/complaints/:complaintId',
+  authenticate,
+  enforceTenantContext,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId, complaintId } = req.params
+      const { status, rejectionReason } = req.body
+      const permissions = req.user!.permissions
+      const userId      = req.user!.userId
+
+      if (!status) {
+        return sendError(res, 'missing_field', 400, { field: 'status' })
+      }
+
+      if (!['RESOLVED', 'REJECTED'].includes(status)) {
+        return sendError(res, 'invalid_status', 400)
+      }
+
+      const complaint = await prisma.complaint.findFirst({
+        where: { id: complaintId, orgId }
+      })
+
+      if (!complaint) {
+        return sendNotFound(res, 'complaint_not_found')
+      }
+
+      if (complaint.status === 'RESOLVED') {
+        return sendError(res, 'already_resolved', 400)
+      }
+
+      if (complaint.status === 'REJECTED') {
+        return sendError(res, 'already_rejected', 400)
+      }
+
+      // Check permissions
+      const canResolveAny = permissions.includes('complaint.resolve_any')
+      const canResolveOwn = permissions.includes('complaint.resolve_own')
+      const canReject     = permissions.includes('complaint.reject')
+
+      if (status === 'REJECTED') {
+        if (!canReject) {
+          return sendError(res, 'insufficient_permissions', 403)
+        }
+        if (!rejectionReason) {
+          return sendError(res, 'rejection_reason_required', 400)
+        }
+      }
+
+      if (status === 'RESOLVED') {
+        if (!canResolveAny && !canResolveOwn) {
+          return sendError(res, 'insufficient_permissions', 403)
+        }
+        if (canResolveOwn && !canResolveAny && complaint.raisedBy !== userId) {
+          return sendError(res, 'cannot_resolve_others', 403)
+        }
+      }
+
+      // Update complaint
+      const updated = await prisma.complaint.update({
+        where: { id: complaintId },
+        data: {
+          status,
+          rejectionReason: rejectionReason ?? null,
+          resolvedAt:      status === 'RESOLVED' ? new Date() : null,
+          resolvedBy:      status === 'RESOLVED' ? userId : null
+        },
+        include: {
+          resolver: {
+            include: { person: true }
+          }
+        }
+      })
+
+      // Notify complainant if admin resolved/rejected
+      if (userId !== complaint.raisedBy) {
+        const notifTitle = status === 'RESOLVED'
+          ? 'Complaint Resolved'
+          : 'Complaint Update'
+        const notifBody = status === 'RESOLVED'
+          ? 'Your complaint has been resolved'
+          : 'Your complaint was not accepted'
+
+        await sendPushNotification(complaint.raisedBy, notifTitle, notifBody)
+      }
+
+      // Notify admin if resident resolved own complaint
+      if (userId === complaint.raisedBy && status === 'RESOLVED') {
+        const adminMembers = await prisma.membership.findMany({
+          where: {
+            orgId,
+            isActive: true,
+            role: { name: { in: ['Builder', 'Admin'] } }
+          },
+          select: { userId: true }
+        })
+
+        const raiser = await prisma.person.findFirst({
+          where: { userId }
+        })
+        const raiserName = raiser?.fullName ?? 'A resident'
+
+        for (const member of adminMembers) {
+          await sendPushNotification(
+            member.userId,
+            'Complaint Closed',
+            `${raiserName} marked their complaint as resolved`
+          )
+        }
+      }
+
+      return sendSuccess(res, {
+        id:         updated.id,
+        status:     updated.status,
+        resolvedAt: updated.resolvedAt,
+        resolvedBy: updated.resolver?.person?.fullName ?? null
+      })
+
+    } catch (error) {
+      console.error('PATCH /complaints/:id error:', error)
+      return sendError(res, 'server_error', 500)
+    }
+  }
+)
+
+export default router

--- a/apps/api/src/utils/cloudinary.ts
+++ b/apps/api/src/utils/cloudinary.ts
@@ -1,0 +1,33 @@
+import { v2 as cloudinary } from 'cloudinary'
+
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key:    process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET
+})
+
+export const uploadImage = async (
+  base64Image: string,
+  folder: string = 'complaints'
+): Promise<string> => {
+  const result = await cloudinary.uploader.upload(base64Image, {
+    folder: `vaastio/${folder}`,
+    resource_type: 'image',
+    allowed_formats: ['jpg', 'jpeg', 'png'],
+    transformation: [
+      { quality: 'auto' },
+      { fetch_format: 'auto' }
+    ]
+  })
+  return result.secure_url
+}
+
+export const uploadMultipleImages = async (
+  base64Images: string[],
+  folder: string = 'complaints'
+): Promise<string[]> => {
+  const uploads = await Promise.all(
+    base64Images.map(img => uploadImage(img, folder))
+  )
+  return uploads
+}

--- a/apps/api/tests/complaints.test.ts
+++ b/apps/api/tests/complaints.test.ts
@@ -1,0 +1,349 @@
+import request from 'supertest'
+import app from '../src/app'
+import { getTokens, getSocietyId } from './setup'
+import { prisma } from '../src/lib/prisma'
+
+describe('Complaints', () => {
+  let builderToken: string
+  let residentToken: string
+  let gatekeeperToken: string
+  let societyId: string
+  let complaintId: string
+
+  beforeAll(async () => {
+    const tokens = await getTokens()
+    builderToken    = tokens['Builder']
+    residentToken   = tokens['Resident']
+    gatekeeperToken = tokens['Gatekeeper']
+    societyId       = await getSocietyId()
+  })
+
+  // ─────────────────────────────────────────────
+  // POST /societies/:id/complaints
+  // ─────────────────────────────────────────────
+  describe('POST /complaints', () => {
+    it('returns 401 with no token', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .send({})
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 403 for builder', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({
+          title: 'Test',
+          description: 'Test description',
+          category: 'NOISE'
+        })
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('insufficient_permissions')
+    })
+
+    it('returns 400 with missing fields', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({ title: 'Test' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('missing_field')
+    })
+
+    it('returns 400 with invalid category', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({
+          title: 'Test',
+          description: 'Test description',
+          category: 'INVALID'
+        })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('invalid_category')
+    })
+
+    it('returns 400 with too many images', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({
+          title: 'Test',
+          description: 'Test description',
+          category: 'NOISE',
+          images: ['a', 'b', 'c', 'd', 'e', 'f']
+        })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('too_many_images')
+    })
+
+    it('creates complaint successfully', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({
+          title: 'Lift not working',
+          description: 'Tower A lift out of service since 2 days',
+          category: 'LIFT_ELEVATOR',
+          visibility: 'PUBLIC'
+        })
+      expect(res.status).toBe(201)
+      expect(res.body.data.title).toBe('Lift not working')
+      expect(res.body.data.status).toBe('OPEN')
+      expect(res.body.data.visibility).toBe('PUBLIC')
+      complaintId = res.body.data.id
+    })
+
+    it('defaults to PRIVATE visibility', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({
+          title: 'Noise from neighbour',
+          description: 'Loud music every night after 11pm',
+          category: 'NOISE'
+        })
+      expect(res.status).toBe(201)
+      expect(res.body.data.visibility).toBe('PRIVATE')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // GET /societies/:id/complaints
+  // ─────────────────────────────────────────────
+  describe('GET /complaints', () => {
+    it('returns 401 with no token', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints`)
+      expect(res.status).toBe(401)
+    })
+
+    it('builder sees all complaints', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.complaints.length).toBeGreaterThan(0)
+      expect(res.body.data.total).toBeDefined()
+      expect(res.body.data.pages).toBeDefined()
+    })
+
+    it('builder sees raisedBy name', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(200)
+      const complaint = res.body.data.complaints[0]
+      expect(complaint.raisedBy).toBe('Arjun Mehta')
+    })
+
+    it('resident sees own complaints', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(res.status).toBe(200)
+      const own = res.body.data.complaints.filter((c: any) => c.raisedByMe)
+      expect(own.length).toBeGreaterThan(0)
+    })
+
+    it('resident sees public complaints from others', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(res.status).toBe(200)
+      const publicOthers = res.body.data.complaints.filter(
+        (c: any) => !c.raisedByMe && c.visibility === 'PUBLIC'
+      )
+      expect(publicOthers.every((c: any) => c.raisedBy === null)).toBe(true)
+    })
+
+    it('filters by status correctly', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints?status=OPEN`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.complaints.every(
+        (c: any) => c.status === 'OPEN'
+      )).toBe(true)
+    })
+
+    it('returns 400 for invalid status', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints?status=WRONG`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('invalid_status')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // GET /societies/:id/complaints/:complaintId
+  // ─────────────────────────────────────────────
+  describe('GET /complaints/:id', () => {
+    it('returns 401 with no token', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints/${complaintId}`)
+      expect(res.status).toBe(401)
+    })
+
+    it('builder sees full details', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints/${complaintId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.description).toBeDefined()
+      expect(res.body.data.raisedBy.name).toBe('Arjun Mehta')
+      expect(res.body.data.raisedBy.phone).toBe('+919222222222')
+    })
+
+    it('resident sees own complaint full details', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints/${complaintId}`)
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.title).toBe('Lift not working')
+    })
+
+    it('returns 404 for non existent complaint', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}/complaints/00000000-0000-0000-0000-000000000000`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(404)
+      expect(res.body.error).toBe('complaint_not_found')
+    })
+
+    it('resident cannot see private complaint from others', async () => {
+  const list = await request(app)
+    .get(`/api/societies/${societyId}/complaints`)
+    .set('Authorization', `Bearer ${builderToken}`)
+  const privateComplaint = list.body.data.complaints.find(
+    (c: any) => c.visibility === 'PRIVATE'
+  )
+
+  const res = await request(app)
+    .get(`/api/societies/${societyId}/complaints/${privateComplaint.id}`)
+    .set('Authorization', `Bearer ${gatekeeperToken}`)
+  expect(res.status).toBe(404)
+})
+  })
+
+  // ─────────────────────────────────────────────
+  // PATCH /societies/:id/complaints/:complaintId
+  // ─────────────────────────────────────────────
+  describe('PATCH /complaints/:id', () => {
+    it('returns 401 with no token', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/complaints/${complaintId}`)
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 400 with missing status', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/complaints/${complaintId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({})
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('missing_field')
+    })
+
+    it('returns 400 with invalid status', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/complaints/${complaintId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ status: 'IN_PROGRESS' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('invalid_status')
+    })
+
+    it('returns 400 reject without reason', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/complaints/${complaintId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ status: 'REJECTED' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('rejection_reason_required')
+    })
+
+    it('returns 403 resident trying to reject', async () => {
+      // create fresh complaint
+      const created = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({
+          title: 'Fresh complaint',
+          description: 'Description here',
+          category: 'NOISE'
+        })
+      const freshId = created.body.data.id
+
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/complaints/${freshId}`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({ status: 'REJECTED', rejectionReason: 'test' })
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('insufficient_permissions')
+    })
+
+    it('builder resolves complaint', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/complaints/${complaintId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ status: 'RESOLVED' })
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('RESOLVED')
+      expect(res.body.data.resolvedAt).toBeDefined()
+      expect(res.body.data.resolvedBy).toBe('Vikram Builder')
+    })
+
+    it('returns 400 when already resolved', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/complaints/${complaintId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ status: 'RESOLVED' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('already_resolved')
+    })
+
+    it('builder rejects complaint with reason', async () => {
+      const created = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({
+          title: 'Another complaint',
+          description: 'Description',
+          category: 'PARKING'
+        })
+      const id = created.body.data.id
+
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/complaints/${id}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({
+          status: 'REJECTED',
+          rejectionReason: 'Duplicate complaint'
+        })
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('REJECTED')
+    })
+
+    it('resident resolves own complaint', async () => {
+      const created = await request(app)
+        .post(`/api/societies/${societyId}/complaints`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({
+          title: 'Water issue',
+          description: 'No water in morning',
+          category: 'WATER_SUPPLY'
+        })
+      const id = created.body.data.id
+
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/complaints/${id}`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({ status: 'RESOLVED' })
+      expect(res.status).toBe(200)
+      expect(res.body.data.status).toBe('RESOLVED')
+    })
+  })
+})

--- a/docs/API.md
+++ b/docs/API.md
@@ -1011,3 +1011,179 @@ an occupancy that was ended (moved out scenario).
 403 insufficient_permissions → Admin cannot reactivate
 403 tenant_context_mismatch
 404 member_not_found
+
+
+### POST /societies/:id/complaints
+Raise a new complaint.
+
+**Auth:** Required
+**Permission:** complaint.create (Resident, Co-resident only)
+
+**Request:**
+```json
+{
+  "title": "Lift not working since 2 days",
+  "description": "Tower A lift is completely out of service.",
+  "category": "LIFT_ELEVATOR",
+  "visibility": "PUBLIC",
+  "images": []
+}
+```
+
+**Categories:**
+WATER_SUPPLY, ELECTRICITY, LIFT_ELEVATOR, GENERATOR,
+INTERNET_CABLE, PARKING, GARBAGE_WASTE, GARDEN_LANDSCAPING,
+GYM_CLUBHOUSE, SWIMMING_POOL, SECURITY, NOISE, PET_RELATED,
+DOMESTIC_HELP, NEIGHBOUR_BEHAVIOUR, STAFF_BEHAVIOUR,
+MAINTENANCE_REPAIR, RULE_VIOLATION, OTHER
+
+**Response 201:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "title": "Lift not working since 2 days",
+    "category": "LIFT_ELEVATOR",
+    "visibility": "PUBLIC",
+    "status": "OPEN",
+    "imageCount": 0,
+    "createdAt": "datetime"
+  }
+}
+```
+
+**Errors:**
+400 missing_field           → title, description or category missing
+400 invalid_category        → category not in allowed values
+400 invalid_visibility      → visibility not PUBLIC or PRIVATE
+400 too_many_images         → more than 5 images provided
+400 image_upload_failed     → Cloudinary upload error
+403 insufficient_permissions → admin/builder trying to raise
+401 no_token                → not logged in
+
+---
+
+### GET /societies/:id/complaints
+List complaints.
+
+**Auth:** Required
+
+**Query params:**
+status   → OPEN, RESOLVED, REJECTED
+category → any valid category
+page     → default 1
+limit    → default 20, max 50
+
+**Behaviour:**
+Admin/Builder → sees all complaints, raisedBy always shown
+Resident/Co-resident → sees own + public complaints
+  raisedBy hidden on other residents' public complaints
+
+**Response 200:**
+```json
+{
+  "data": {
+    "complaints": [
+      {
+        "id": "uuid",
+        "title": "Lift not working since 2 days",
+        "category": "LIFT_ELEVATOR",
+        "visibility": "PUBLIC",
+        "status": "OPEN",
+        "raisedBy": "Arjun Mehta",
+        "raisedByMe": true,
+        "imageCount": 0,
+        "createdAt": "datetime"
+      }
+    ],
+    "total": 1,
+    "page": 1,
+    "pages": 1
+  }
+}
+```
+
+---
+
+### GET /societies/:id/complaints/:complaintId
+Complaint detail.
+
+**Auth:** Required
+
+**Behaviour:**
+Admin/Builder → any complaint
+Resident → own + public only
+Private complaint from others → 404 complaint_not_found
+
+**Response 200:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "title": "Lift not working since 2 days",
+    "description": "Full description here",
+    "category": "LIFT_ELEVATOR",
+    "visibility": "PUBLIC",
+    "status": "OPEN",
+    "rejectionReason": null,
+    "raisedBy": {
+      "name": "Arjun Mehta",
+      "phone": "+919222222222"
+    },
+    "resolvedBy": null,
+    "resolvedAt": null,
+    "images": [
+      { "id": "uuid", "imageUrl": "https://res.cloudinary.com/..." }
+    ],
+    "createdAt": "datetime",
+    "updatedAt": "datetime"
+  }
+}
+```
+
+**Errors:**
+404 complaint_not_found → not found or no access
+401 no_token            → not logged in
+
+---
+
+### PATCH /societies/:id/complaints/:complaintId
+Update complaint status.
+
+**Auth:** Required
+
+**Request — resolve:**
+```json
+{ "status": "RESOLVED" }
+```
+
+**Request — reject (admin only):**
+```json
+{
+  "status": "REJECTED",
+  "rejectionReason": "Duplicate complaint"
+}
+```
+
+**Response 200:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "status": "RESOLVED",
+    "resolvedAt": "datetime",
+    "resolvedBy": "Vikram Builder"
+  }
+}
+```
+
+**Errors:**
+400 missing_field            → status not provided
+400 invalid_status           → not RESOLVED or REJECTED
+400 already_resolved         → complaint already resolved
+400 already_rejected         → complaint already rejected
+400 rejection_reason_required → rejected without reason
+403 insufficient_permissions  → resident trying to reject
+403 cannot_resolve_others     → resident resolving others' complaint
+404 complaint_not_found       → complaint not found
+401 no_token                  → not logged in

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^5.22.0",
+        "cloudinary": "^2.9.0",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
         "prisma": "^5.22.0"
@@ -7282,6 +7283,18 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-2.9.0.tgz",
+      "integrity": "sha512-F3iKMOy4y0zy0bi5JBp94SC7HY7i/ImfTPSUV07iJmRzH1Iz8WavFfOlJTR1zvYM/xKGoiGZ3my/zy64In0IQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=9"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -12011,6 +12024,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",


### PR DESCRIPTION
- Complaint schema — complaints + complaint_images tables
- POST /societies/:id/complaints — raise complaint with images
- GET /societies/:id/complaints — list with visibility rules
- GET /societies/:id/complaints/:id — detail with access control
- PATCH /societies/:id/complaints/:id — resolve and reject
- Cloudinary integration for image uploads
- Push notifications on all complaint events
- complaint permissions added to all role bundles
- seed.ts fixed — removed duplicate permissions
- 21 complaint tests — all passing
- API.md updated