### PR TITLE
feat: complaint mobile screens — list, raise, detail with notifications and image upload

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,7 +13,8 @@ import { apiRateLimit } from './middleware/rateLimit'
 
 const app = express()
 
-app.use(express.json())
+app.use(express.json({ limit: '50mb' }))
+app.use(express.urlencoded({ limit: '50mb', extended: true }))
 app.use(apiRateLimit)
 
 app.use('/api', testRouter)

--- a/apps/api/src/routes/complaints.ts
+++ b/apps/api/src/routes/complaints.ts
@@ -57,6 +57,7 @@ router.post(
         try {
           imageUrls = await uploadMultipleImages(images)
         } catch (uploadError) {
+          console.error('Cloudinary upload error:', uploadError)
           return sendError(res, 'image_upload_failed', 400)
         }
       }

--- a/apps/api/src/utils/cloudinary.ts
+++ b/apps/api/src/utils/cloudinary.ts
@@ -10,7 +10,13 @@ export const uploadImage = async (
   base64Image: string,
   folder: string = 'complaints'
 ): Promise<string> => {
-  const result = await cloudinary.uploader.upload(base64Image, {
+  // expo-image-picker returns raw base64 without the data URI prefix.
+  // Cloudinary requires "data:image/jpeg;base64,..." — prepend if missing.
+  const dataUri = base64Image.startsWith('data:')
+    ? base64Image
+    : `data:image/jpeg;base64,${base64Image}`
+
+  const result = await cloudinary.uploader.upload(dataUri, {
     folder: `vaastio/${folder}`,
     resource_type: 'image',
     allowed_formats: ['jpg', 'jpeg', 'png'],

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -13,6 +13,8 @@
     "@react-navigation/native-stack": "^7.14.10",
     "axios": "^1.14.0",
     "expo": "~54.0.33",
+    "expo-image-picker": "~17.0.10",
+    "expo-notifications": "~0.32.16",
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -26,7 +26,7 @@ interface AuthState {
 }
 
 interface AuthContextValue extends AuthState {
-  loadUser: () => Promise<void>
+  loadUser: (showLoading?: boolean) => Promise<void>
   signOut: () => Promise<void>
   hasPermission: (permission: string) => boolean
 }
@@ -43,7 +43,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isAuthenticated: false,
   })
 
-  const loadUser = useCallback(async () => {
+  const loadUser = useCallback(async (showLoading = false) => {
+    // showLoading: true → briefly shows LoadingSpinner during navigator switch
+    // (use when called after login/name-save to prevent AuthNavigator→AppNavigator flash)
+    // showLoading: false (default) → silent refresh, used for pull-to-refresh from screens
+    if (showLoading) {
+      setState((s) => ({ ...s, isLoading: true }))
+    }
     try {
       const token = await getStoredToken()
       if (!token) {

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react'
 import * as SecureStore from 'expo-secure-store'
 import { getMe, clearTokens, getStoredToken } from '../services/auth'
+import { registerDeviceToken } from '../services/notifications'
 
 interface User {
   id: string
@@ -72,6 +73,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         isLoading: false,
         isAuthenticated: true,
       })
+
+      // Register push token — fire-and-forget, never blocks auth flow
+      registerDeviceToken()
     } catch {
       setState((s) => ({ ...s, isLoading: false, isAuthenticated: false }))
     }

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -8,6 +8,9 @@ import { InviteMemberScreen } from '../screens/society/InviteMemberScreen'
 import { MemberListScreen } from '../screens/members/MemberListScreen'
 import { MemberDetailScreen } from '../screens/members/MemberDetailScreen'
 import { SwitchSocietyScreen } from '../screens/society/SwitchSocietyScreen'
+import { ComplaintListScreen } from '../screens/complaints/ComplaintListScreen'
+import { RaiseComplaintScreen } from '../screens/complaints/RaiseComplaintScreen'
+import { ComplaintDetailScreen } from '../screens/complaints/ComplaintDetailScreen'
 import { Colors } from '../constants/colors'
 
 export type AppStackParamList = {
@@ -19,6 +22,9 @@ export type AppStackParamList = {
   InviteMember: { societyId: string }
   MemberList: { societyId: string }
   MemberDetail: { societyId: string; memberId: string; memberName: string }
+  ComplaintList: { societyId: string }
+  RaiseComplaint: { societyId: string }
+  ComplaintDetail: { societyId: string; complaintId: string; title: string }
 }
 
 const Stack = createNativeStackNavigator<AppStackParamList>()
@@ -52,6 +58,9 @@ export function AppNavigator({ initialSocietyId }: AppNavigatorProps) {
       <Stack.Screen name="MemberList" component={MemberListScreen} options={{ title: 'Members' }} />
       <Stack.Screen name="MemberDetail" component={MemberDetailScreen} options={({ route }) => ({ title: route.params.memberName })} />
       <Stack.Screen name="SwitchSociety" component={SwitchSocietyScreen} options={{ title: 'Switch Society' }} />
+      <Stack.Screen name="ComplaintList" component={ComplaintListScreen} options={{ title: 'Complaints' }} />
+      <Stack.Screen name="RaiseComplaint" component={RaiseComplaintScreen} options={{ title: 'Raise Complaint' }} />
+      <Stack.Screen name="ComplaintDetail" component={ComplaintDetailScreen} options={({ route }) => ({ title: route.params.title })} />
     </Stack.Navigator>
   )
 }

--- a/apps/mobile/src/screens/auth/LoginOTPScreen.tsx
+++ b/apps/mobile/src/screens/auth/LoginOTPScreen.tsx
@@ -77,7 +77,7 @@ export function LoginOTPScreen({ route, navigation }: Props) {
         if (data.currentOrg?.id) {
           await saveCurrentOrg(data.currentOrg.id)
         }
-        await loadUser()
+        await loadUser(true)
       }
     } catch (e) {
       const code = getApiErrorCode(e)

--- a/apps/mobile/src/screens/auth/SelectSocietyScreen.tsx
+++ b/apps/mobile/src/screens/auth/SelectSocietyScreen.tsx
@@ -27,7 +27,7 @@ export function SelectSocietyScreen({ route }: Props) {
       const data = await selectOrg(orgId)
       await saveSessionToken(data.token)
       await saveCurrentOrg(orgId)
-      await loadUser()
+      await loadUser(true)
     } catch (e) {
       const code = getApiErrorCode(e)
       setToast({ message: getErrorMessage(code), type: 'error' })

--- a/apps/mobile/src/screens/auth/SetNameScreen.tsx
+++ b/apps/mobile/src/screens/auth/SetNameScreen.tsx
@@ -38,8 +38,9 @@ export function SetNameScreen({ route, navigation }: Props) {
         if (currentOrgId) {
           await saveCurrentOrg(currentOrgId)
         }
-        await loadUser()
-        // RootNavigator switches to AppNavigator automatically
+        // showLoading=true: covers AuthNavigator→AppNavigator swap with spinner,
+        // preventing the flash between SetNameScreen and the first app screen
+        await loadUser(true)
       }
     } catch (e) {
       const code = getApiErrorCode(e)

--- a/apps/mobile/src/screens/complaints/ComplaintDetailScreen.tsx
+++ b/apps/mobile/src/screens/complaints/ComplaintDetailScreen.tsx
@@ -1,0 +1,711 @@
+import React, { useCallback, useState, useEffect } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  RefreshControl,
+  Modal,
+  TouchableWithoutFeedback,
+  TextInput as RNTextInput,
+  Image,
+  Pressable,
+  StyleSheet,
+} from 'react-native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { Button } from '../../components/Button'
+import { LoadingSpinner } from '../../components/LoadingSpinner'
+import { EmptyState } from '../../components/EmptyState'
+import { Toast } from '../../components/Toast'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
+import { getComplaint, updateComplaintStatus, ComplaintDetail } from '../../services/complaints'
+import { CATEGORY_LABEL, CATEGORY_ICON, STATUS_LABEL, STATUS_COLORS } from '../../utils/complaintMeta'
+import { getApiErrorCode } from '../../services/api'
+import { getErrorMessage } from '../../utils/errorMessages'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'ComplaintDetail'>
+
+const REJECTION_REASONS = [
+  'Duplicate complaint',
+  'Outside society jurisdiction',
+  'Invalid or incomplete information',
+  'Other',
+]
+
+export function ComplaintDetailScreen({ route }: Props) {
+  const { societyId, complaintId } = route.params
+  const { permissions, user } = useAuth()
+
+  const isAdmin = permissions.includes('member.view')
+
+  const [complaint, setComplaint] = useState<ComplaintDetail | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [imageModalUri, setImageModalUri] = useState<string | null>(null)
+  const [showResolveSheet, setShowResolveSheet] = useState(false)
+  const [showRejectSheet, setShowRejectSheet] = useState(false)
+  const [selectedReason, setSelectedReason] = useState<string | null>(null)
+  const [customReason, setCustomReason] = useState('')
+  const [isActioning, setIsActioning] = useState(false)
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const data = await getComplaint(societyId, complaintId)
+      setComplaint(data)
+      setLoadError(null)
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      setLoadError(getErrorMessage(code))
+    } finally {
+      setIsLoading(false)
+      setIsRefreshing(false)
+    }
+  }, [societyId, complaintId])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const onRefresh = useCallback(() => {
+    setIsRefreshing(true)
+    load()
+  }, [load])
+
+  // Determine permissions for actions
+  const isMyComplaint = !!complaint?.raisedBy && complaint.raisedBy.phone === user?.phone
+  const canResolve = complaint?.status === 'OPEN' && (isAdmin || isMyComplaint)
+  const canReject = complaint?.status === 'OPEN' && isAdmin
+  const hasActions = canResolve || canReject
+
+  async function handleResolve() {
+    setIsActioning(true)
+    try {
+      await updateComplaintStatus(societyId, complaintId, 'RESOLVED')
+      setShowResolveSheet(false)
+      setToast({ message: 'Complaint marked as resolved.', type: 'success' })
+      load()
+    } catch (e) {
+      setShowResolveSheet(false)
+      setToast({ message: getErrorMessage(getApiErrorCode(e)), type: 'error' })
+    } finally {
+      setIsActioning(false)
+    }
+  }
+
+  function closeRejectSheet() {
+    setShowRejectSheet(false)
+    setSelectedReason(null)
+    setCustomReason('')
+  }
+
+  async function handleReject() {
+    const reason = selectedReason === 'Other' ? customReason.trim() : selectedReason
+    if (!reason) return
+    setIsActioning(true)
+    try {
+      await updateComplaintStatus(societyId, complaintId, 'REJECTED', reason)
+      closeRejectSheet()
+      setToast({ message: 'Complaint rejected.', type: 'info' })
+      load()
+    } catch (e) {
+      closeRejectSheet()
+      setToast({ message: getErrorMessage(getApiErrorCode(e)), type: 'error' })
+    } finally {
+      setIsActioning(false)
+    }
+  }
+
+  if (isLoading) return <LoadingSpinner fullScreen />
+
+  if (loadError || !complaint) {
+    return (
+      <EmptyState
+        title="Could not load complaint"
+        subtitle={loadError ?? 'Something went wrong.'}
+        actionLabel="Retry"
+        onAction={() => {
+          setIsLoading(true)
+          load()
+        }}
+      />
+    )
+  }
+
+  const resolveReason = selectedReason === 'Other' ? customReason.trim() : selectedReason
+
+  return (
+    <ScreenWrapper scroll={false} style={styles.wrapper}>
+      {/* ── Scrollable content ── */}
+      <ScrollView
+        contentContainerStyle={[styles.content, hasActions && styles.contentWithActions]}
+        showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={onRefresh}
+            tintColor={Colors.primary}
+            colors={[Colors.primary]}
+          />
+        }
+      >
+        {/* Status badge */}
+        <View style={styles.statusRow}>
+          <View style={[styles.statusBadge, { backgroundColor: STATUS_COLORS[complaint.status].bg }]}>
+            <Text style={[styles.statusText, { color: STATUS_COLORS[complaint.status].text }]}>
+              {STATUS_LABEL[complaint.status]}
+            </Text>
+          </View>
+        </View>
+
+        {/* Title */}
+        <Text style={styles.title}>{complaint.title}</Text>
+
+        {/* Category + Visibility tags */}
+        <View style={styles.tagsRow}>
+          <View style={styles.tag}>
+            <Text style={styles.tagText}>
+              {CATEGORY_ICON[complaint.category]}{'  '}{CATEGORY_LABEL[complaint.category]}
+            </Text>
+          </View>
+          <View style={styles.tag}>
+            <Text style={styles.tagText}>
+              {complaint.visibility === 'PUBLIC' ? '🌐  Public' : '🔒  Private'}
+            </Text>
+          </View>
+        </View>
+
+        {/* Description */}
+        <Text style={styles.description}>{complaint.description}</Text>
+
+        {/* Images */}
+        {complaint.images.length > 0 ? (
+          <View style={styles.imagesSection}>
+            <Text style={styles.sectionLabel}>Photos</Text>
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={styles.imagesScroll}
+            >
+              {complaint.images.map((img) => (
+                <Pressable
+                  key={img.id}
+                  onPress={() => setImageModalUri(img.imageUrl)}
+                  style={({ pressed }) => pressed && styles.thumbnailPressed}
+                >
+                  <Image source={{ uri: img.imageUrl }} style={styles.imageThumbnail} />
+                </Pressable>
+              ))}
+            </ScrollView>
+          </View>
+        ) : null}
+
+        {/* Meta: raised by / date */}
+        <View style={styles.metaCard}>
+          {isAdmin && complaint.raisedBy ? (
+            <MetaRow label="Raised by" value={complaint.raisedBy.name} />
+          ) : null}
+          <MetaRow label="Raised on" value={formatDate(complaint.createdAt)} />
+        </View>
+
+        {/* Resolved info */}
+        {complaint.status === 'RESOLVED' && complaint.resolvedBy ? (
+          <View style={styles.resolvedCard}>
+            <Text style={styles.resolvedCardLabel}>Resolved</Text>
+            <MetaRow label="Resolved by" value={complaint.resolvedBy} />
+            {complaint.resolvedAt ? (
+              <MetaRow label="Resolved on" value={formatDate(complaint.resolvedAt)} />
+            ) : null}
+          </View>
+        ) : null}
+
+        {/* Rejection reason */}
+        {complaint.status === 'REJECTED' && complaint.rejectionReason ? (
+          <View style={styles.rejectedCard}>
+            <Text style={styles.rejectedCardLabel}>Reason for Rejection</Text>
+            <Text style={styles.rejectedReason}>{complaint.rejectionReason}</Text>
+          </View>
+        ) : null}
+      </ScrollView>
+
+      {/* ── Bottom action bar ── */}
+      {hasActions ? (
+        <View style={styles.actionBar}>
+          {canResolve ? (
+            <Button
+              label="Mark Resolved"
+              onPress={() => setShowResolveSheet(true)}
+              style={styles.actionBtn}
+            />
+          ) : null}
+          {canReject ? (
+            <Button
+              label="Reject"
+              variant="danger"
+              onPress={() => setShowRejectSheet(true)}
+              style={styles.actionBtn}
+            />
+          ) : null}
+        </View>
+      ) : null}
+
+      {/* ── Resolve confirmation sheet ── */}
+      <ResolveSheet
+        visible={showResolveSheet}
+        loading={isActioning}
+        onConfirm={handleResolve}
+        onClose={() => setShowResolveSheet(false)}
+      />
+
+      {/* ── Reject sheet ── */}
+      <RejectSheet
+        visible={showRejectSheet}
+        selectedReason={selectedReason}
+        customReason={customReason}
+        canConfirm={!!resolveReason}
+        loading={isActioning}
+        onSelectReason={setSelectedReason}
+        onChangeCustomReason={setCustomReason}
+        onConfirm={handleReject}
+        onClose={closeRejectSheet}
+      />
+
+      {/* ── Full-screen image viewer ── */}
+      <Modal
+        visible={!!imageModalUri}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setImageModalUri(null)}
+      >
+        <Pressable style={styles.imageModal} onPress={() => setImageModalUri(null)}>
+          {imageModalUri ? (
+            <Image
+              source={{ uri: imageModalUri }}
+              style={styles.imageModalContent}
+              resizeMode="contain"
+            />
+          ) : null}
+        </Pressable>
+      </Modal>
+
+      {toast ? (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          visible={!!toast}
+          onHide={() => setToast(null)}
+        />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── MetaRow ──────────────────────────────────────────────────────────────────
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View style={metaRowStyles.row}>
+      <Text style={metaRowStyles.label}>{label}</Text>
+      <Text style={metaRowStyles.value}>{value}</Text>
+    </View>
+  )
+}
+
+const metaRowStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  label: { fontSize: 14, color: Colors.subtle },
+  value: { fontSize: 14, fontWeight: '500', color: Colors.text },
+})
+
+// ─── ResolveSheet ─────────────────────────────────────────────────────────────
+
+function ResolveSheet({
+  visible,
+  loading,
+  onConfirm,
+  onClose,
+}: {
+  visible: boolean
+  loading: boolean
+  onConfirm: () => void
+  onClose: () => void
+}) {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View style={sheetStyles.overlay} />
+      </TouchableWithoutFeedback>
+      <View style={sheetStyles.sheet}>
+        <View style={sheetStyles.handle} />
+        <View style={sheetStyles.body}>
+          <Text style={sheetStyles.title}>Mark as Resolved?</Text>
+          <Text style={sheetStyles.message}>
+            This will mark the complaint as resolved. This action cannot be undone.
+          </Text>
+        </View>
+        <View style={sheetStyles.actions}>
+          <Button label="Mark Resolved" onPress={onConfirm} loading={loading} />
+          <Button label="Cancel" variant="secondary" onPress={onClose} disabled={loading} />
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+// ─── RejectSheet ──────────────────────────────────────────────────────────────
+
+interface RejectSheetProps {
+  visible: boolean
+  selectedReason: string | null
+  customReason: string
+  canConfirm: boolean
+  loading: boolean
+  onSelectReason: (r: string) => void
+  onChangeCustomReason: (t: string) => void
+  onConfirm: () => void
+  onClose: () => void
+}
+
+function RejectSheet({
+  visible,
+  selectedReason,
+  customReason,
+  canConfirm,
+  loading,
+  onSelectReason,
+  onChangeCustomReason,
+  onConfirm,
+  onClose,
+}: RejectSheetProps) {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <TouchableWithoutFeedback onPress={onClose}>
+        <View style={sheetStyles.overlay} />
+      </TouchableWithoutFeedback>
+
+      <View style={sheetStyles.sheet}>
+        <View style={sheetStyles.handle} />
+        <Text style={rejectStyles.sheetTitle}>Reject Complaint</Text>
+
+        {REJECTION_REASONS.map((reason, i) => {
+          const isSelected = selectedReason === reason
+          const isLast = i === REJECTION_REASONS.length - 1
+          return (
+            <Pressable
+              key={reason}
+              onPress={() => onSelectReason(reason)}
+              style={({ pressed }) => [
+                rejectStyles.option,
+                !isLast && rejectStyles.optionBorder,
+                isSelected && rejectStyles.optionSelected,
+                pressed && rejectStyles.optionPressed,
+              ]}
+            >
+              <View style={[rejectStyles.radio, isSelected && rejectStyles.radioActive]}>
+                {isSelected ? <View style={rejectStyles.radioDot} /> : null}
+              </View>
+              <Text style={[rejectStyles.optionText, isSelected && rejectStyles.optionTextActive]}>
+                {reason}
+              </Text>
+            </Pressable>
+          )
+        })}
+
+        {selectedReason === 'Other' ? (
+          <View style={rejectStyles.customWrap}>
+            <RNTextInput
+              value={customReason}
+              onChangeText={onChangeCustomReason}
+              placeholder="Describe the reason..."
+              placeholderTextColor={Colors.subtle}
+              style={rejectStyles.customInput}
+              multiline
+              numberOfLines={2}
+              textAlignVertical="top"
+              autoFocus
+            />
+          </View>
+        ) : null}
+
+        <View style={sheetStyles.actions}>
+          <Button
+            label="Confirm Rejection"
+            variant="danger"
+            onPress={onConfirm}
+            disabled={!canConfirm}
+            loading={loading}
+          />
+          <Button label="Cancel" variant="secondary" onPress={onClose} disabled={loading} />
+        </View>
+      </View>
+    </Modal>
+  )
+}
+
+// ─── Shared sheet styles ───────────────────────────────────────────────────────
+
+const sheetStyles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' },
+  sheet: {
+    backgroundColor: Colors.surface,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingBottom: 36,
+  },
+  handle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: Colors.border,
+    alignSelf: 'center',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  body: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 20,
+    gap: 8,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: Colors.text,
+  },
+  message: {
+    fontSize: 14,
+    color: Colors.subtle,
+    lineHeight: 21,
+  },
+  actions: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingTop: 12,
+    gap: 10,
+  },
+})
+
+const rejectStyles = StyleSheet.create({
+  sheetTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: Colors.text,
+    textAlign: 'center',
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  option: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 14,
+    paddingHorizontal: Spacing.screenPadding,
+    gap: 12,
+    minHeight: Spacing.minTapTarget,
+  },
+  optionBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  optionSelected: { backgroundColor: '#ede9fe' },
+  optionPressed: { backgroundColor: Colors.background },
+  optionText: { fontSize: 15, color: Colors.text, flex: 1 },
+  optionTextActive: { color: Colors.primary, fontWeight: '600' },
+  radio: {
+    width: 20,
+    height: 20,
+    borderRadius: 10,
+    borderWidth: 2,
+    borderColor: Colors.border,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  radioActive: { borderColor: Colors.primary },
+  radioDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: Colors.primary,
+  },
+  customWrap: {
+    marginHorizontal: Spacing.screenPadding,
+    marginTop: 4,
+    marginBottom: 8,
+  },
+  customInput: {
+    height: 72,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 15,
+    color: Colors.text,
+    backgroundColor: Colors.surface,
+  },
+})
+
+// ─── Main screen styles ───────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  wrapper: { backgroundColor: Colors.background },
+
+  content: {
+    padding: Spacing.screenPadding,
+    gap: Spacing.sectionGap,
+    paddingBottom: 32,
+  },
+  contentWithActions: {
+    paddingBottom: 100, // space for bottom action bar
+  },
+
+  // Status badge (large, prominent at top)
+  statusRow: { flexDirection: 'row' },
+  statusBadge: {
+    paddingHorizontal: 14,
+    paddingVertical: 7,
+    borderRadius: 8,
+  },
+  statusText: {
+    fontSize: 13,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+  },
+
+  // Title
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: Colors.text,
+    lineHeight: 30,
+    marginTop: -8,
+  },
+
+  // Tags row
+  tagsRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+  tag: {
+    backgroundColor: Colors.surface,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  tagText: { fontSize: 13, color: Colors.subtle, fontWeight: '500' },
+
+  // Description
+  description: {
+    fontSize: 16,
+    color: Colors.text,
+    lineHeight: 24,
+  },
+
+  // Images
+  imagesSection: { gap: 10 },
+  sectionLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.subtle,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  imagesScroll: { gap: 10 },
+  imageThumbnail: {
+    width: 120,
+    height: 120,
+    borderRadius: 10,
+    backgroundColor: Colors.border,
+  },
+  thumbnailPressed: { opacity: 0.8 },
+
+  // Meta card
+  metaCard: {
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    padding: 16,
+    gap: 12,
+  },
+
+  // Resolved card (green tint)
+  resolvedCard: {
+    backgroundColor: '#f0fdf4',
+    borderWidth: 1,
+    borderColor: '#bbf7d0',
+    borderRadius: 12,
+    padding: 16,
+    gap: 10,
+  },
+  resolvedCardLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: Colors.success,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+
+  // Rejected card (red tint)
+  rejectedCard: {
+    backgroundColor: '#fff1f2',
+    borderWidth: 1,
+    borderColor: '#fecdd3',
+    borderRadius: 12,
+    padding: 16,
+    gap: 6,
+  },
+  rejectedCardLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: Colors.error,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  rejectedReason: {
+    fontSize: 15,
+    color: '#991b1b',
+    lineHeight: 22,
+  },
+
+  // Bottom action bar
+  actionBar: {
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 14,
+    backgroundColor: Colors.surface,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+  },
+  actionBtn: { flex: 1 },
+
+  // Full-screen image modal
+  imageModal: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.92)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  imageModalContent: {
+    width: '100%',
+    height: '80%',
+  },
+})
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-IN', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}

--- a/apps/mobile/src/screens/complaints/ComplaintListScreen.tsx
+++ b/apps/mobile/src/screens/complaints/ComplaintListScreen.tsx
@@ -1,0 +1,398 @@
+import React, { useEffect, useCallback, useState, useRef } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  RefreshControl,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { useFocusEffect } from '@react-navigation/native'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { LoadingSpinner } from '../../components/LoadingSpinner'
+import { Toast } from '../../components/Toast'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
+import { listComplaints, ComplaintListItem, ComplaintStatus } from '../../services/complaints'
+import { CATEGORY_LABEL, CATEGORY_ICON, STATUS_LABEL, STATUS_COLORS } from '../../utils/complaintMeta'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'ComplaintList'>
+
+type StatusFilter = 'ALL' | ComplaintStatus
+
+const FILTERS: { label: string; value: StatusFilter }[] = [
+  { label: 'All', value: 'ALL' },
+  { label: 'Open', value: 'OPEN' },
+  { label: 'Resolved', value: 'RESOLVED' },
+  { label: 'Rejected', value: 'REJECTED' },
+]
+
+// Mixed data type for FlatList (complaints + section headers)
+type ListItem =
+  | { _kind: 'header'; id: string; title: string }
+  | { _kind: 'empty_section'; id: string; message: string }
+  | { _kind: 'complaint'; data: ComplaintListItem }
+
+const PAGE_SIZE = 20
+
+export function ComplaintListScreen({ route, navigation }: Props) {
+  const { societyId } = route.params
+  const { permissions } = useAuth()
+
+  const isAdmin = permissions.includes('member.view')
+  const canCreate = permissions.includes('complaint.create')
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ALL')
+  const [complaints, setComplaints] = useState<ComplaintListItem[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  // Header right: "+" button if user can create
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight: canCreate
+        ? () => (
+            <TouchableOpacity
+              onPress={() => navigation.navigate('RaiseComplaint', { societyId })}
+              hitSlop={12}
+              style={styles.headerBtn}
+            >
+              <Text style={styles.headerBtnText}>+</Text>
+            </TouchableOpacity>
+          )
+        : undefined,
+    })
+  }, [canCreate, navigation, societyId])
+
+  const load = useCallback(
+    async (page: number, reset: boolean) => {
+      try {
+        if (reset) setIsLoading(true)
+        else setIsLoadingMore(true)
+
+        const params: Parameters<typeof listComplaints>[1] = { page, limit: PAGE_SIZE }
+        if (statusFilter !== 'ALL') params.status = statusFilter
+
+        const result = await listComplaints(societyId, params)
+        if (!isMounted.current) return
+
+        setComplaints((prev) => (reset ? result.complaints : [...prev, ...result.complaints]))
+        setCurrentPage(page)
+        setHasMore(page < result.pages)
+      } catch {
+        if (isMounted.current) {
+          setToast({ message: 'Could not load complaints. Pull to retry.', type: 'error' })
+        }
+      } finally {
+        if (isMounted.current) {
+          setIsLoading(false)
+          setIsRefreshing(false)
+          setIsLoadingMore(false)
+        }
+      }
+    },
+    [societyId, statusFilter],
+  )
+
+  // Reload on focus (handles returning from RaiseComplaint / ComplaintDetail)
+  // and whenever filter changes (load changes when statusFilter changes)
+  useFocusEffect(
+    useCallback(() => {
+      load(1, true)
+    }, [load]),
+  )
+
+  const onRefresh = useCallback(() => {
+    setIsRefreshing(true)
+    load(1, true)
+  }, [load])
+
+  const onLoadMore = useCallback(() => {
+    if (isLoadingMore || !hasMore) return
+    load(currentPage + 1, false)
+  }, [isLoadingMore, hasMore, currentPage, load])
+
+  const listData = buildListData(complaints, isAdmin)
+
+  const renderItem = ({ item }: { item: ListItem }) => {
+    if (item._kind === 'header') {
+      return (
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionHeaderText}>{item.title}</Text>
+        </View>
+      )
+    }
+
+    if (item._kind === 'empty_section') {
+      return (
+        <View style={styles.emptySection}>
+          <Text style={styles.emptySectionText}>{item.message}</Text>
+        </View>
+      )
+    }
+
+    const c = item.data
+    return (
+      <Pressable
+        onPress={() =>
+          navigation.navigate('ComplaintDetail', {
+            societyId,
+            complaintId: c.id,
+            title: c.title,
+          })
+        }
+        style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+      >
+        <View style={styles.rowIcon}>
+          <Text style={styles.rowIconText}>{CATEGORY_ICON[c.category] ?? '📋'}</Text>
+        </View>
+        <View style={styles.rowContent}>
+          <View style={styles.rowTop}>
+            <Text style={styles.rowTitle} numberOfLines={1}>
+              {c.title}
+            </Text>
+            <View style={[styles.statusBadge, { backgroundColor: STATUS_COLORS[c.status].bg }]}>
+              <Text style={[styles.statusText, { color: STATUS_COLORS[c.status].text }]}>
+                {STATUS_LABEL[c.status]}
+              </Text>
+            </View>
+          </View>
+          <View style={styles.rowMeta}>
+            <Text style={styles.rowMetaText}>{CATEGORY_LABEL[c.category] ?? c.category}</Text>
+            {isAdmin && c.raisedBy ? (
+              <Text style={styles.rowMetaText}>· {c.raisedBy}</Text>
+            ) : null}
+            <Text style={styles.rowMetaText}>· {formatDate(c.createdAt)}</Text>
+          </View>
+        </View>
+        <Text style={styles.chevron}>›</Text>
+      </Pressable>
+    )
+  }
+
+  if (isLoading) return <LoadingSpinner fullScreen />
+
+  return (
+    <ScreenWrapper scroll={false} style={styles.wrapper}>
+      {/* Filter chips */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chips}
+        style={styles.chipBar}
+      >
+        {FILTERS.map((f) => (
+          <Pressable
+            key={f.value}
+            onPress={() => setStatusFilter(f.value)}
+            style={[styles.chip, statusFilter === f.value && styles.chipActive]}
+          >
+            <Text style={[styles.chipText, statusFilter === f.value && styles.chipTextActive]}>
+              {f.label}
+            </Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+
+      {/* Complaint list */}
+      <FlatList
+        data={listData}
+        keyExtractor={(item) => (item._kind === 'complaint' ? item.data.id : item.id)}
+        renderItem={renderItem}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={onRefresh}
+            tintColor={Colors.primary}
+            colors={[Colors.primary]}
+          />
+        }
+        onEndReached={onLoadMore}
+        onEndReachedThreshold={0.3}
+        ListEmptyComponent={
+          <View style={styles.emptyFull}>
+            <Text style={styles.emptyTitle}>No complaints</Text>
+            <Text style={styles.emptySub}>
+              {statusFilter === 'ALL'
+                ? 'Nothing here yet.'
+                : `No ${statusFilter.toLowerCase()} complaints.`}
+            </Text>
+          </View>
+        }
+        ListFooterComponent={isLoadingMore ? <LoadingSpinner /> : null}
+        contentContainerStyle={listData.length === 0 ? styles.emptyContainer : undefined}
+        style={styles.list}
+      />
+
+      {toast ? (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          visible={!!toast}
+          onHide={() => setToast(null)}
+        />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildListData(complaints: ComplaintListItem[], isAdmin: boolean): ListItem[] {
+  if (isAdmin) {
+    return complaints.map((c) => ({ _kind: 'complaint', data: c }))
+  }
+
+  const mine = complaints.filter((c) => c.raisedByMe)
+  const publicOthers = complaints.filter((c) => !c.raisedByMe)
+
+  return [
+    { _kind: 'header', id: '__my_header', title: 'MY COMPLAINTS' },
+    ...mine.map((c): ListItem => ({ _kind: 'complaint', data: c })),
+    ...(mine.length === 0
+      ? [{ _kind: 'empty_section' as const, id: '__my_empty', message: 'No complaints raised yet' }]
+      : []),
+    { _kind: 'header', id: '__pub_header', title: 'PUBLIC COMPLAINTS' },
+    ...publicOthers.map((c): ListItem => ({ _kind: 'complaint', data: c })),
+    ...(publicOthers.length === 0
+      ? [{ _kind: 'empty_section' as const, id: '__pub_empty', message: 'No public complaints from others' }]
+      : []),
+  ]
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-IN', { day: 'numeric', month: 'short' })
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  wrapper: { backgroundColor: Colors.background },
+
+  // Filter chips
+  chipBar: { flexShrink: 0 },
+  chips: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 12,
+    gap: 8,
+  },
+  chip: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: Colors.surface,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  chipActive: {
+    backgroundColor: Colors.primary,
+    borderColor: Colors.primary,
+  },
+  chipText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: Colors.subtle,
+  },
+  chipTextActive: {
+    color: Colors.surface,
+  },
+
+  // List
+  list: { flex: 1 },
+
+  // Section header
+  sectionHeader: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingTop: 16,
+    paddingBottom: 8,
+    backgroundColor: Colors.background,
+  },
+  sectionHeaderText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.subtle,
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
+  },
+
+  // Empty section
+  emptySection: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 20,
+    alignItems: 'center',
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  emptySectionText: { fontSize: 14, color: Colors.subtle },
+
+  // Complaint row
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 14,
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    gap: 12,
+    minHeight: Spacing.minTapTarget,
+  },
+  rowPressed: { backgroundColor: Colors.background },
+  rowIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    backgroundColor: '#ede9fe',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  rowIconText: { fontSize: 18 },
+  rowContent: { flex: 1, gap: 4 },
+  rowTop: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  rowTitle: { flex: 1, fontSize: 15, fontWeight: '600', color: Colors.text },
+  statusBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+    flexShrink: 0,
+  },
+  statusText: { fontSize: 11, fontWeight: '600' },
+  rowMeta: { flexDirection: 'row', alignItems: 'center', gap: 4, flexWrap: 'wrap' },
+  rowMetaText: { fontSize: 12, color: Colors.subtle },
+  chevron: { fontSize: 22, color: Colors.subtle, lineHeight: 26 },
+
+  // Full empty state
+  emptyContainer: { flexGrow: 1 },
+  emptyFull: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 8,
+  },
+  emptyTitle: { fontSize: 17, fontWeight: '600', color: Colors.text },
+  emptySub: { fontSize: 14, color: Colors.subtle, textAlign: 'center' },
+
+  // Header button
+  headerBtn: { marginRight: 4, padding: 4 },
+  headerBtnText: { fontSize: 26, color: Colors.primary, fontWeight: '400', lineHeight: 30 },
+})

--- a/apps/mobile/src/screens/complaints/ComplaintListScreen.tsx
+++ b/apps/mobile/src/screens/complaints/ComplaintListScreen.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   StyleSheet,
   TouchableOpacity,
+  Platform,
 } from 'react-native'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { useFocusEffect } from '@react-navigation/native'
@@ -64,22 +65,6 @@ export function ComplaintListScreen({ route, navigation }: Props) {
     }
   }, [])
 
-  // Header right: "+" button if user can create
-  useEffect(() => {
-    navigation.setOptions({
-      headerRight: canCreate
-        ? () => (
-            <TouchableOpacity
-              onPress={() => navigation.navigate('RaiseComplaint', { societyId })}
-              hitSlop={12}
-              style={styles.headerBtn}
-            >
-              <Text style={styles.headerBtnText}>+</Text>
-            </TouchableOpacity>
-          )
-        : undefined,
-    })
-  }, [canCreate, navigation, societyId])
 
   const load = useCallback(
     async (page: number, reset: boolean) => {
@@ -241,6 +226,17 @@ export function ComplaintListScreen({ route, navigation }: Props) {
         style={styles.list}
       />
 
+      {/* FAB — raise complaint */}
+      {canCreate ? (
+        <TouchableOpacity
+          onPress={() => navigation.navigate('RaiseComplaint', { societyId })}
+          style={styles.fab}
+          activeOpacity={0.85}
+        >
+          <Text style={styles.fabText}>+</Text>
+        </TouchableOpacity>
+      ) : null}
+
       {toast ? (
         <Toast
           message={toast.message}
@@ -396,7 +392,28 @@ const styles = StyleSheet.create({
   emptyTitle: { fontSize: 17, fontWeight: '600', color: Colors.text },
   emptySub: { fontSize: 14, color: Colors.subtle, textAlign: 'center' },
 
-  // Header button
-  headerBtn: { marginRight: 4, padding: 4 },
-  headerBtnText: { fontSize: 26, color: Colors.primary, fontWeight: '400', lineHeight: 30 },
+  // FAB
+  fab: {
+    position: 'absolute',
+    right: 20,
+    bottom: Platform.OS === 'ios' ? 36 : 24,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+    elevation: 6,
+  },
+  fabText: {
+    fontSize: 28,
+    color: Colors.surface,
+    fontWeight: '400',
+    lineHeight: 34,
+    marginTop: -2,
+  },
 })

--- a/apps/mobile/src/screens/complaints/ComplaintListScreen.tsx
+++ b/apps/mobile/src/screens/complaints/ComplaintListScreen.tsx
@@ -287,11 +287,15 @@ const styles = StyleSheet.create({
   wrapper: { backgroundColor: Colors.background },
 
   // Filter chips
-  chipBar: { flexShrink: 0 },
+  chipBar: {
+    flexGrow: 0,   // don't expand to fill flex parent
+    flexShrink: 0,
+  },
   chips: {
     paddingHorizontal: Spacing.screenPadding,
     paddingVertical: 12,
     gap: 8,
+    alignItems: 'center', // keep chips at their intrinsic height, not stretched
   },
   chip: {
     paddingHorizontal: 16,

--- a/apps/mobile/src/screens/complaints/RaiseComplaintScreen.tsx
+++ b/apps/mobile/src/screens/complaints/RaiseComplaintScreen.tsx
@@ -1,0 +1,398 @@
+// Requires: npx expo install expo-image-picker
+import React, { useState } from 'react'
+import {
+  View,
+  Text,
+  Pressable,
+  Image,
+  StyleSheet,
+} from 'react-native'
+import * as ImagePicker from 'expo-image-picker'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { TextInput } from '../../components/TextInput'
+import { Button } from '../../components/Button'
+import { Toast } from '../../components/Toast'
+import { BottomSheetPicker } from '../../components/BottomSheetPicker'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { raiseComplaint, ComplaintCategory, ComplaintVisibility } from '../../services/complaints'
+import { ALL_CATEGORIES, CATEGORY_LABEL } from '../../utils/complaintMeta'
+import { getApiErrorCode, getApiErrorDetails } from '../../services/api'
+import { getErrorMessage } from '../../utils/errorMessages'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'RaiseComplaint'>
+
+const MAX_IMAGES = 5
+
+interface SelectedImage {
+  uri: string
+  base64: string
+}
+
+interface FieldErrors {
+  title?: string
+  description?: string
+  category?: string
+}
+
+const CATEGORY_OPTIONS = ALL_CATEGORIES.map((c) => ({
+  label: CATEGORY_LABEL[c],
+  value: c,
+}))
+
+export function RaiseComplaintScreen({ route, navigation }: Props) {
+  const { societyId } = route.params
+
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [category, setCategory] = useState<ComplaintCategory | null>(null)
+  const [visibility, setVisibility] = useState<ComplaintVisibility>('PRIVATE')
+  const [images, setImages] = useState<SelectedImage[]>([])
+  const [errors, setErrors] = useState<FieldErrors>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false)
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+
+  function clearError(field: keyof FieldErrors) {
+    setErrors((prev) => ({ ...prev, [field]: undefined }))
+  }
+
+  function validate(): boolean {
+    const next: FieldErrors = {}
+    if (!title.trim()) next.title = 'Title is required.'
+    if (!description.trim()) next.description = 'Description is required.'
+    if (!category) next.category = 'Please select a category.'
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  async function pickImages() {
+    if (images.length >= MAX_IMAGES) {
+      setToast({ message: `Maximum ${MAX_IMAGES} images allowed.`, type: 'error' })
+      return
+    }
+
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync()
+    if (status !== 'granted') {
+      setToast({ message: 'Allow photo access to attach images.', type: 'info' })
+      return
+    }
+
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsMultipleSelection: true,
+      selectionLimit: MAX_IMAGES - images.length,
+      base64: true,
+      quality: 0.7,
+    })
+
+    if (result.canceled) return
+
+    const picked: SelectedImage[] = (result.assets as Array<{ uri: string; base64?: string | null }>)
+      .filter((a) => !!a.base64)
+      .map((a) => ({ uri: a.uri, base64: a.base64! }))
+
+    setImages((prev) => [...prev, ...picked].slice(0, MAX_IMAGES))
+  }
+
+  function removeImage(index: number) {
+    setImages((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  async function handleSubmit() {
+    if (!validate() || !category) return
+
+    setIsSubmitting(true)
+    try {
+      await raiseComplaint(societyId, {
+        title: title.trim(),
+        description: description.trim(),
+        category,
+        visibility,
+        images: images.map((img) => img.base64),
+      })
+
+      setToast({ message: 'Complaint raised successfully.', type: 'success' })
+      setTimeout(() => navigation.goBack(), 1500)
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      const details = getApiErrorDetails(e)
+      const field = details.field as string | undefined
+
+      if (code === 'missing_field' && field === 'title') {
+        setErrors((prev) => ({ ...prev, title: 'Title is required.' }))
+      } else if (code === 'missing_field' && field === 'description') {
+        setErrors((prev) => ({ ...prev, description: 'Description is required.' }))
+      } else {
+        setToast({ message: getErrorMessage(code), type: 'error' })
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <ScreenWrapper contentStyle={styles.content}>
+      {/* Title */}
+      <TextInput
+        label="Title"
+        placeholder="What is the issue?"
+        value={title}
+        onChangeText={(t) => {
+          setTitle(t)
+          if (errors.title) clearError('title')
+        }}
+        error={errors.title}
+        maxLength={120}
+        returnKeyType="next"
+      />
+
+      {/* Description */}
+      <TextInput
+        label="Description"
+        placeholder="Describe the issue in detail..."
+        value={description}
+        onChangeText={(t) => {
+          setDescription(t)
+          if (errors.description) clearError('description')
+        }}
+        error={errors.description}
+        multiline
+        numberOfLines={4}
+        style={styles.descriptionInput}
+        textAlignVertical="top"
+      />
+
+      {/* Category */}
+      <View style={styles.field}>
+        <Text style={styles.fieldLabel}>Category</Text>
+        <Pressable
+          onPress={() => setShowCategoryPicker(true)}
+          style={({ pressed }) => [
+            styles.pickerTrigger,
+            errors.category ? styles.pickerTriggerError : null,
+            pressed && styles.pickerTriggerPressed,
+          ]}
+        >
+          <Text style={[styles.pickerText, !category && styles.pickerPlaceholder]}>
+            {category ? CATEGORY_LABEL[category] : 'Select a category'}
+          </Text>
+          <Text style={styles.pickerChevron}>›</Text>
+        </Pressable>
+        {errors.category ? <Text style={styles.errorText}>{errors.category}</Text> : null}
+      </View>
+
+      {/* Visibility toggle */}
+      <View style={styles.field}>
+        <Text style={styles.fieldLabel}>Visibility</Text>
+        <View style={styles.visibilityRow}>
+          <Pressable
+            onPress={() => setVisibility('PRIVATE')}
+            style={[styles.visibilityCard, visibility === 'PRIVATE' && styles.visibilityCardActive]}
+          >
+            <Text style={styles.visibilityIcon}>🔒</Text>
+            <Text style={[styles.visibilityLabel, visibility === 'PRIVATE' && styles.visibilityLabelActive]}>
+              Private
+            </Text>
+            <Text style={styles.visibilityDesc}>Only admins can see this</Text>
+          </Pressable>
+
+          <Pressable
+            onPress={() => setVisibility('PUBLIC')}
+            style={[styles.visibilityCard, visibility === 'PUBLIC' && styles.visibilityCardActive]}
+          >
+            <Text style={styles.visibilityIcon}>🌐</Text>
+            <Text style={[styles.visibilityLabel, visibility === 'PUBLIC' && styles.visibilityLabelActive]}>
+              Public
+            </Text>
+            <Text style={styles.visibilityDesc}>Visible to all residents</Text>
+          </Pressable>
+        </View>
+      </View>
+
+      {/* Image picker */}
+      <View style={styles.field}>
+        <Text style={styles.fieldLabel}>
+          Photos{' '}
+          <Text style={styles.fieldLabelOptional}>(optional, up to {MAX_IMAGES})</Text>
+        </Text>
+        <View style={styles.imagesRow}>
+          {images.map((img, i) => (
+            <View key={i} style={styles.thumbnailWrapper}>
+              <Image source={{ uri: img.uri }} style={styles.thumbnail} />
+              <Pressable style={styles.removeBtn} onPress={() => removeImage(i)} hitSlop={8}>
+                <Text style={styles.removeBtnText}>✕</Text>
+              </Pressable>
+            </View>
+          ))}
+          {images.length < MAX_IMAGES ? (
+            <Pressable onPress={pickImages} style={styles.addPhotoBtn}>
+              <Text style={styles.addPhotoPlus}>+</Text>
+              <Text style={styles.addPhotoLabel}>Add Photos</Text>
+              <Text style={styles.addPhotoCount}>
+                {images.length}/{MAX_IMAGES}
+              </Text>
+            </Pressable>
+          ) : null}
+        </View>
+      </View>
+
+      {/* Submit */}
+      <Button
+        label="Submit Complaint"
+        onPress={handleSubmit}
+        loading={isSubmitting}
+        style={styles.submitBtn}
+      />
+
+      {/* Category picker sheet */}
+      <BottomSheetPicker
+        visible={showCategoryPicker}
+        title="Select Category"
+        options={CATEGORY_OPTIONS}
+        selected={category}
+        onSelect={(v) => {
+          setCategory(v as ComplaintCategory)
+          clearError('category')
+        }}
+        onClose={() => setShowCategoryPicker(false)}
+      />
+
+      {toast ? (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          visible={!!toast}
+          onHide={() => setToast(null)}
+        />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  content: {
+    gap: Spacing.sectionGap,
+    paddingBottom: 40,
+  },
+
+  // Multiline description — overrides the fixed height in TextInput
+  descriptionInput: {
+    height: 110,
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+
+  // Generic field wrapper
+  field: { gap: 6 },
+  fieldLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: Colors.text,
+  },
+  fieldLabelOptional: {
+    fontSize: 13,
+    fontWeight: '400',
+    color: Colors.subtle,
+  },
+  errorText: {
+    fontSize: 13,
+    color: Colors.error,
+  },
+
+  // Category picker trigger
+  pickerTrigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: 52,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    backgroundColor: Colors.surface,
+  },
+  pickerTriggerError: { borderColor: Colors.error },
+  pickerTriggerPressed: { backgroundColor: Colors.background },
+  pickerText: { flex: 1, fontSize: 16, color: Colors.text },
+  pickerPlaceholder: { color: Colors.subtle },
+  pickerChevron: { fontSize: 20, color: Colors.subtle },
+
+  // Visibility toggle
+  visibilityRow: { flexDirection: 'row', gap: 10 },
+  visibilityCard: {
+    flex: 1,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    borderRadius: 12,
+    paddingVertical: 16,
+    paddingHorizontal: 12,
+    backgroundColor: Colors.surface,
+    alignItems: 'center',
+    gap: 4,
+  },
+  visibilityCardActive: {
+    borderColor: Colors.primary,
+    backgroundColor: '#ede9fe',
+  },
+  visibilityIcon: { fontSize: 22 },
+  visibilityLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.text,
+  },
+  visibilityLabelActive: { color: Colors.primary },
+  visibilityDesc: {
+    fontSize: 11,
+    color: Colors.subtle,
+    textAlign: 'center',
+    lineHeight: 16,
+  },
+
+  // Image row
+  imagesRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  thumbnailWrapper: { position: 'relative' },
+  thumbnail: {
+    width: 80,
+    height: 80,
+    borderRadius: 10,
+    backgroundColor: Colors.border,
+  },
+  removeBtn: {
+    position: 'absolute',
+    top: -7,
+    right: -7,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: Colors.error,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  removeBtnText: { fontSize: 11, color: Colors.surface, fontWeight: '700' },
+  addPhotoBtn: {
+    width: 80,
+    height: 80,
+    borderRadius: 10,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    borderStyle: 'dashed',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.surface,
+    gap: 2,
+  },
+  addPhotoPlus: { fontSize: 22, color: Colors.subtle, lineHeight: 26 },
+  addPhotoLabel: { fontSize: 10, color: Colors.subtle, fontWeight: '500' },
+  addPhotoCount: { fontSize: 10, color: Colors.subtle },
+
+  // Submit
+  submitBtn: { marginTop: 4 },
+})

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -129,7 +129,9 @@ export function DashboardScreen({ route, navigation }: Props) {
   const canViewMembers = permissions.includes('member.view')
   const canSwitchSociety = memberships.length > 1
   const canViewComplaints =
-    permissions.includes('complaint.create') || permissions.includes('complaint.view_own')
+    permissions.includes('complaint.create') ||
+    permissions.includes('complaint.view_own') ||
+    permissions.includes('complaint.view_all')
 
   const hasAnyAction = canViewStructure || canInvite || canViewMembers || canSwitchSociety || canViewComplaints
 

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react'
+import React, { useEffect, useCallback, useState } from 'react'
 import {
   View,
   Text,
@@ -7,6 +7,8 @@ import {
   Pressable,
   StyleSheet,
   TouchableOpacity,
+  Modal,
+  TouchableWithoutFeedback,
 } from 'react-native'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { ScreenWrapper } from '../../components/ScreenWrapper'
@@ -14,9 +16,14 @@ import { Card } from '../../components/Card'
 import { LoadingSpinner } from '../../components/LoadingSpinner'
 import { EmptyState } from '../../components/EmptyState'
 import { Toast } from '../../components/Toast'
+import { TextInput } from '../../components/TextInput'
+import { Button } from '../../components/Button'
 import { AppStackParamList } from '../../navigation/AppNavigator'
 import { useAuth } from '../../hooks/useAuth'
 import { useSociety } from '../../hooks/useSociety'
+import { updateProfile } from '../../services/auth'
+import { getApiErrorCode } from '../../services/api'
+import { getErrorMessage } from '../../utils/errorMessages'
 import { Colors } from '../../constants/colors'
 import { Spacing } from '../../constants/spacing'
 
@@ -31,12 +38,49 @@ const SOCIETY_TYPE_LABEL: Record<string, string> = {
 
 export function DashboardScreen({ route, navigation }: Props) {
   const { societyId } = route.params
-  const { permissions, isLoading: authLoading, loadUser, signOut, memberships } = useAuth()
+  const { permissions, isLoading: authLoading, loadUser, signOut, memberships, user } = useAuth()
   const { society, isLoading: societyLoading, error, load } = useSociety(societyId)
 
   const isLoading = authLoading || societyLoading
 
   const role = memberships.find((m) => m.org.id === societyId)?.role ?? null
+
+  // Profile sheet state
+  const [showProfile, setShowProfile] = useState(false)
+  const [profileName, setProfileName] = useState('')
+  const [profileError, setProfileError] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+  const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null)
+
+  function openProfile() {
+    setProfileName(user?.name ?? '')
+    setProfileError('')
+    setShowProfile(true)
+  }
+
+  async function handleSaveName() {
+    const trimmed = profileName.trim()
+    if (trimmed.length < 2) {
+      setProfileError('Name must be at least 2 characters.')
+      return
+    }
+    setIsSaving(true)
+    try {
+      await updateProfile(trimmed)
+      await loadUser()
+      setShowProfile(false)
+      setToast({ message: 'Name updated.', type: 'success' })
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      if (code === 'missing_field' || code === 'invalid_name') {
+        setProfileError(getErrorMessage(code))
+      } else {
+        setProfileError(getErrorMessage(code))
+      }
+    } finally {
+      setIsSaving(false)
+    }
+  }
 
   useEffect(() => {
     load()
@@ -48,6 +92,22 @@ export function DashboardScreen({ route, navigation }: Props) {
 
   const canCreateSociety = permissions.includes('society.create')
 
+  // Profile avatar in header left — always visible
+  useEffect(() => {
+    const initial = (user?.name ?? '?').trim().charAt(0).toUpperCase()
+    navigation.setOptions({
+      headerLeft: () => (
+        <TouchableOpacity onPress={openProfile} hitSlop={12} style={styles.headerAvatarBtn}>
+          <View style={styles.headerAvatar}>
+            <Text style={styles.headerAvatarText}>{initial}</Text>
+          </View>
+        </TouchableOpacity>
+      ),
+    })
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.name, navigation])
+
+  // "+" to create another society — builders only
   useEffect(() => {
     if (!canCreateSociety) return
     navigation.setOptions({
@@ -195,6 +255,59 @@ export function DashboardScreen({ route, navigation }: Props) {
           </Pressable>
         </View>
       </ScrollView>
+
+      {/* ── Profile sheet ── */}
+      <Modal
+        visible={showProfile}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setShowProfile(false)}
+      >
+        <TouchableWithoutFeedback onPress={() => setShowProfile(false)}>
+          <View style={profileStyles.overlay} />
+        </TouchableWithoutFeedback>
+
+        <View style={profileStyles.sheet}>
+          <View style={profileStyles.handle} />
+
+          <View style={profileStyles.body}>
+            <Text style={profileStyles.title}>Edit Name</Text>
+            {user ? (
+              <Text style={profileStyles.phoneHint}>{user.phone}</Text>
+            ) : null}
+            <TextInput
+              label="Full Name"
+              value={profileName}
+              onChangeText={(v) => { setProfileName(v); setProfileError('') }}
+              error={profileError}
+              autoCapitalize="words"
+              autoFocus
+              returnKeyType="done"
+              onSubmitEditing={handleSaveName}
+              maxLength={80}
+            />
+          </View>
+
+          <View style={profileStyles.actions}>
+            <Button label="Save" onPress={handleSaveName} loading={isSaving} />
+            <Button
+              label="Cancel"
+              variant="secondary"
+              onPress={() => setShowProfile(false)}
+              disabled={isSaving}
+            />
+          </View>
+        </View>
+      </Modal>
+
+      {toast ? (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          visible={!!toast}
+          onHide={() => setToast(null)}
+        />
+      ) : null}
     </ScreenWrapper>
   )
 }
@@ -405,5 +518,64 @@ const styles = StyleSheet.create({
     color: Colors.primary,
     fontWeight: '400',
     lineHeight: 30,
+  },
+
+  // Header avatar (profile button)
+  headerAvatarBtn: {
+    marginLeft: 4,
+    padding: 4,
+  },
+  headerAvatar: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerAvatarText: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: Colors.surface,
+  },
+})
+
+// ─── Profile sheet styles ─────────────────────────────────────────────────────
+
+const profileStyles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' },
+  sheet: {
+    backgroundColor: Colors.surface,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingBottom: 36,
+  },
+  handle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: Colors.border,
+    alignSelf: 'center',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  body: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 20,
+    gap: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: Colors.text,
+  },
+  phoneHint: {
+    fontSize: 13,
+    color: Colors.subtle,
+    marginTop: -6,
+  },
+  actions: {
+    paddingHorizontal: Spacing.screenPadding,
+    gap: 10,
   },
 })

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -68,8 +68,10 @@ export function DashboardScreen({ route, navigation }: Props) {
   const canInvite = permissions.includes('invitation.create')
   const canViewMembers = permissions.includes('member.view')
   const canSwitchSociety = memberships.length > 1
+  const canViewComplaints =
+    permissions.includes('complaint.create') || permissions.includes('complaint.view_own')
 
-  const hasAnyAction = canViewStructure || canInvite || canViewMembers || canSwitchSociety
+  const hasAnyAction = canViewStructure || canInvite || canViewMembers || canSwitchSociety || canViewComplaints
 
   if (isLoading) {
     return <LoadingSpinner fullScreen />
@@ -164,6 +166,14 @@ export function DashboardScreen({ route, navigation }: Props) {
                   label="View Members"
                   subtitle="Active residents and staff"
                   onPress={() => navigation.navigate('MemberList', { societyId })}
+                />
+              ) : null}
+              {canViewComplaints ? (
+                <ActionRow
+                  icon="📋"
+                  label="Complaints"
+                  subtitle="View and raise complaints"
+                  onPress={() => navigation.navigate('ComplaintList', { societyId })}
                 />
               ) : null}
               {canSwitchSociety ? (

--- a/apps/mobile/src/services/complaints.ts
+++ b/apps/mobile/src/services/complaints.ts
@@ -1,0 +1,106 @@
+import api from './api'
+
+export type ComplaintStatus = 'OPEN' | 'RESOLVED' | 'REJECTED'
+
+export type ComplaintCategory =
+  | 'WATER_SUPPLY'
+  | 'ELECTRICITY'
+  | 'LIFT_ELEVATOR'
+  | 'GENERATOR'
+  | 'INTERNET_CABLE'
+  | 'PARKING'
+  | 'GARBAGE_WASTE'
+  | 'GARDEN_LANDSCAPING'
+  | 'GYM_CLUBHOUSE'
+  | 'SWIMMING_POOL'
+  | 'SECURITY'
+  | 'NOISE'
+  | 'PET_RELATED'
+  | 'DOMESTIC_HELP'
+  | 'NEIGHBOUR_BEHAVIOUR'
+  | 'STAFF_BEHAVIOUR'
+  | 'MAINTENANCE_REPAIR'
+  | 'RULE_VIOLATION'
+  | 'OTHER'
+
+export type ComplaintVisibility = 'PUBLIC' | 'PRIVATE'
+
+export interface ComplaintListItem {
+  id: string
+  title: string
+  category: ComplaintCategory
+  visibility: ComplaintVisibility
+  status: ComplaintStatus
+  raisedBy: string | null
+  raisedByMe: boolean
+  imageCount: number
+  createdAt: string
+}
+
+export interface ComplaintDetail {
+  id: string
+  title: string
+  description: string
+  category: ComplaintCategory
+  visibility: ComplaintVisibility
+  status: ComplaintStatus
+  rejectionReason: string | null
+  raisedBy: { name: string; phone: string } | null
+  resolvedBy: string | null
+  resolvedAt: string | null
+  images: { id: string; imageUrl: string }[]
+  createdAt: string
+  updatedAt: string
+}
+
+export interface ListComplaintsParams {
+  status?: ComplaintStatus
+  category?: ComplaintCategory
+  page?: number
+  limit?: number
+}
+
+export interface ListComplaintsResponse {
+  complaints: ComplaintListItem[]
+  total: number
+  page: number
+  pages: number
+}
+
+export async function listComplaints(
+  societyId: string,
+  params: ListComplaintsParams = {},
+): Promise<ListComplaintsResponse> {
+  const res = await api.get(`/societies/${societyId}/complaints`, { params })
+  return res.data.data
+}
+
+export async function getComplaint(societyId: string, complaintId: string): Promise<ComplaintDetail> {
+  const res = await api.get(`/societies/${societyId}/complaints/${complaintId}`)
+  return res.data.data
+}
+
+export interface RaiseComplaintInput {
+  title: string
+  description: string
+  category: ComplaintCategory
+  visibility: ComplaintVisibility
+  images?: string[]
+}
+
+export async function raiseComplaint(societyId: string, data: RaiseComplaintInput) {
+  const res = await api.post(`/societies/${societyId}/complaints`, data)
+  return res.data.data
+}
+
+export async function updateComplaintStatus(
+  societyId: string,
+  complaintId: string,
+  status: 'RESOLVED' | 'REJECTED',
+  rejectionReason?: string,
+) {
+  const body: { status: string; rejectionReason?: string } = { status }
+  if (rejectionReason) body.rejectionReason = rejectionReason
+  const res = await api.patch(`/societies/${societyId}/complaints/${complaintId}`, body)
+  return res.data.data
+}

--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -4,6 +4,9 @@ import { Platform } from 'react-native'
 import api from './api'
 
 export async function registerDeviceToken(): Promise<void> {
+  // expo-notifications does not support Expo Go (SDK 53+). Skip silently in dev.
+  if (__DEV__) return
+
   try {
     const { status: existing } = await Notifications.getPermissionsAsync()
     let finalStatus = existing

--- a/apps/mobile/src/services/notifications.ts
+++ b/apps/mobile/src/services/notifications.ts
@@ -1,0 +1,31 @@
+import * as Notifications from 'expo-notifications'
+import * as SecureStore from 'expo-secure-store'
+import { Platform } from 'react-native'
+import api from './api'
+
+export async function registerDeviceToken(): Promise<void> {
+  try {
+    const { status: existing } = await Notifications.getPermissionsAsync()
+    let finalStatus = existing
+
+    if (existing !== 'granted') {
+      const { status } = await Notifications.requestPermissionsAsync()
+      finalStatus = status
+    }
+
+    // User denied — silent degradation, never block app
+    if (finalStatus !== 'granted') return
+
+    const { data: pushToken } = await Notifications.getExpoPushTokenAsync()
+
+    // Only re-register if token changed
+    const stored = await SecureStore.getItemAsync('device_token')
+    if (stored === pushToken) return
+
+    const platform = Platform.OS === 'ios' ? 'IOS' : 'ANDROID'
+    await api.post('/auth/device-token', { token: pushToken, platform })
+    await SecureStore.setItemAsync('device_token', pushToken)
+  } catch {
+    // Silent degradation — never surface notification errors to user
+  }
+}

--- a/apps/mobile/src/utils/complaintMeta.ts
+++ b/apps/mobile/src/utils/complaintMeta.ts
@@ -1,0 +1,79 @@
+import { ComplaintCategory, ComplaintStatus } from '../services/complaints'
+
+export const CATEGORY_LABEL: Record<ComplaintCategory, string> = {
+  WATER_SUPPLY: 'Water Supply',
+  ELECTRICITY: 'Electricity',
+  LIFT_ELEVATOR: 'Lift / Elevator',
+  GENERATOR: 'Generator',
+  INTERNET_CABLE: 'Internet & Cable',
+  PARKING: 'Parking',
+  GARBAGE_WASTE: 'Garbage & Waste',
+  GARDEN_LANDSCAPING: 'Garden & Landscaping',
+  GYM_CLUBHOUSE: 'Gym / Clubhouse',
+  SWIMMING_POOL: 'Swimming Pool',
+  SECURITY: 'Security',
+  NOISE: 'Noise',
+  PET_RELATED: 'Pet Related',
+  DOMESTIC_HELP: 'Domestic Help',
+  NEIGHBOUR_BEHAVIOUR: 'Neighbour Behaviour',
+  STAFF_BEHAVIOUR: 'Staff Behaviour',
+  MAINTENANCE_REPAIR: 'Maintenance & Repair',
+  RULE_VIOLATION: 'Rule Violation',
+  OTHER: 'Other',
+}
+
+export const CATEGORY_ICON: Record<ComplaintCategory, string> = {
+  WATER_SUPPLY: '💧',
+  ELECTRICITY: '⚡',
+  LIFT_ELEVATOR: '🔼',
+  GENERATOR: '🔋',
+  INTERNET_CABLE: '📡',
+  PARKING: '🅿️',
+  GARBAGE_WASTE: '🗑️',
+  GARDEN_LANDSCAPING: '🌿',
+  GYM_CLUBHOUSE: '🏋️',
+  SWIMMING_POOL: '🏊',
+  SECURITY: '🔒',
+  NOISE: '📢',
+  PET_RELATED: '🐾',
+  DOMESTIC_HELP: '🧹',
+  NEIGHBOUR_BEHAVIOUR: '👥',
+  STAFF_BEHAVIOUR: '👷',
+  MAINTENANCE_REPAIR: '🔧',
+  RULE_VIOLATION: '⚠️',
+  OTHER: '📋',
+}
+
+export const STATUS_LABEL: Record<ComplaintStatus, string> = {
+  OPEN: 'Open',
+  RESOLVED: 'Resolved',
+  REJECTED: 'Rejected',
+}
+
+export const STATUS_COLORS: Record<ComplaintStatus, { bg: string; text: string }> = {
+  OPEN: { bg: '#fef3c7', text: '#92400e' },
+  RESOLVED: { bg: '#dcfce7', text: '#166534' },
+  REJECTED: { bg: '#fee2e2', text: '#991b1b' },
+}
+
+export const ALL_CATEGORIES: ComplaintCategory[] = [
+  'WATER_SUPPLY',
+  'ELECTRICITY',
+  'LIFT_ELEVATOR',
+  'GENERATOR',
+  'INTERNET_CABLE',
+  'PARKING',
+  'GARBAGE_WASTE',
+  'GARDEN_LANDSCAPING',
+  'GYM_CLUBHOUSE',
+  'SWIMMING_POOL',
+  'SECURITY',
+  'NOISE',
+  'PET_RELATED',
+  'DOMESTIC_HELP',
+  'NEIGHBOUR_BEHAVIOUR',
+  'STAFF_BEHAVIOUR',
+  'MAINTENANCE_REPAIR',
+  'RULE_VIOLATION',
+  'OTHER',
+]

--- a/apps/mobile/src/utils/errorMessages.ts
+++ b/apps/mobile/src/utils/errorMessages.ts
@@ -41,6 +41,17 @@ const ERROR_MAP: Record<string, string> = {
   already_accepted: 'This invitation has already been accepted.',
   invitation_not_found: 'Invitation not found.',
 
+  // Complaints
+  invalid_category: 'Please select a valid category.',
+  invalid_visibility: 'Please select a visibility option.',
+  too_many_images: 'You can only attach up to 5 images.',
+  image_upload_failed: 'Image upload failed. Please try again.',
+  already_resolved: 'This complaint is already resolved.',
+  already_rejected: 'This complaint is already rejected.',
+  rejection_reason_required: 'Please provide a reason for rejection.',
+  cannot_resolve_others: 'You can only resolve your own complaints.',
+  complaint_not_found: 'Complaint not found.',
+
   // Members
   invalid_status: 'Invalid status filter.',
   cannot_deactivate_self: 'You cannot remove yourself.',

--- a/docs/MOBILE_CONTEXT.md
+++ b/docs/MOBILE_CONTEXT.md
@@ -34,8 +34,16 @@ npm install @react-navigation/native-stack
 npm install react-native-screens react-native-safe-area-context
 npm install axios
 npm install expo-secure-store
+npx expo install expo-notifications
+npx expo install expo-image-picker
 npx expo start
 ```
+
+## Installed Packages (beyond create-expo-app)
+
+expo-secure-store      → token storage (session_token, refresh_token, device_token)
+expo-notifications     → push notification permission + Expo push token registration
+expo-image-picker      → photo selection for complaint image upload
 
 ---
 
@@ -98,6 +106,15 @@ Case 3: requiresOrgSelection = true
 → Show society selector
 → POST /auth/select-org to get session token
 → Go to Society Dashboard
+
+After any successful login (AuthContext.loadUser resolves):
+→ registerDeviceToken() called fire-and-forget
+→ Requests notification permission (silent if denied)
+→ If granted: GET Expo push token
+→ POST /auth/device-token { token, platform }
+→ Token cached in SecureStore key: 'device_token'
+→ Re-registers only if token has changed
+→ Never blocks or errors the auth flow
 
 ### Storing Tokens
 
@@ -188,23 +205,30 @@ PATCH  /societies/:id/members/:memberId/reactivate   → restore access
 
 POST /societies/:id/complaints
   Body: title, description, category, visibility, images[]
-  Auth: Resident, Co-resident only
+  Auth: Resident, Co-resident only (complaint.create permission)
+  images[]: base64 encoded strings (up to 5, Cloudinary upload on backend)
   Returns: complaint id, status, createdAt
 
 GET /societies/:id/complaints
-  Query: status, category, page, limit
-  Admin sees all. Resident sees own + public.
-  raisedBy null on others' public complaints.
+  Query: status (OPEN/RESOLVED/REJECTED), category, page (default 1), limit (default 20)
+  Admin/Builder: all complaints, raisedBy always shown
+  Resident/Co-resident: own + public complaints
+    raisedByMe: true/false flag on each item
+    raisedBy null on other residents' public complaints (anonymous)
+  Response shape: { complaints[], total, page, pages }
 
 GET /societies/:id/complaints/:complaintId
-  Admin: any complaint
+  Admin/Builder: any complaint
   Resident: own + public only
-  Private from others → 404
+  Private complaint from others → 404 complaint_not_found
+  Response includes: images[], raisedBy { name, phone }, resolvedBy, resolvedAt, rejectionReason
 
 PATCH /societies/:id/complaints/:complaintId
-  Body: status (RESOLVED/REJECTED), rejectionReason
-  Admin: resolve or reject any
-  Resident: resolve own only
+  Resolve → Body: { status: "RESOLVED" }
+    Admin: resolve any    Resident: resolve own only (cannot_resolve_others if not theirs)
+  Reject  → Body: { status: "REJECTED", rejectionReason: "..." }
+    Admin only (insufficient_permissions for residents)
+  Errors: already_resolved, already_rejected, rejection_reason_required
 
 ### Notification Setup
   POST /auth/device-token
@@ -295,21 +319,61 @@ Role options: Admin, Resident, Gatekeeper, Co-resident
 Shows pending invitations list below form
 Wireframe: approved ✓
 
-### Complaint Screens Needed
-  RaiseComplaintScreen
-    Fields: title, description, category picker,
-            visibility toggle, image picker (max 5)
-    
-  ComplaintListScreen
-    Filter chips: All / Open / Resolved / Rejected
-    My complaints section
-    Public complaints section
-    FAB to raise new complaint
-    
-  ComplaintDetailScreen
-    Full details, images
-    Resolve button (if open + can resolve)
-    Reject flow (admin only, with reason picker)
+### Complaint Screens
+
+**Screen: ComplaintListScreen**
+
+Route: /complaint-list
+Connects to: GET /societies/:id/complaints
+  Query params: status (OPEN/RESOLVED/REJECTED), page, limit
+Filter chips: All / Open / Resolved / Rejected
+Resident view: two sections — MY COMPLAINTS / PUBLIC COMPLAINTS
+  (split client-side using raisedByMe flag from API)
+Admin view: single flat list, raisedBy name shown on each row
+Header right: "+" button — only if complaint.create permission
+Pull to refresh + paginated load-more (20 per page)
+useFocusEffect: reloads whenever screen gains focus
+  (handles returning from RaiseComplaint and ComplaintDetail)
+Tap row → ComplaintDetailScreen
+
+**Screen: RaiseComplaintScreen**
+
+Route: /raise-complaint
+Connects to: POST /societies/:id/complaints
+Fields:
+  title (required)
+  description (multiline, required)
+  category (BottomSheetPicker, required — 19 categories)
+  visibility toggle: Private (default) / Public
+    Private: only admins see it
+    Public: visible to all residents
+  image picker (optional, max 5, expo-image-picker)
+    images converted to base64 (quality 0.7) at pick time
+    sent as images[] in request body
+On success: toast → goBack() after 1.5s
+
+**Screen: ComplaintDetailScreen**
+
+Route: /complaint-detail
+Connects to:
+  GET  /societies/:id/complaints/:id   (load + pull-to-refresh)
+  PATCH /societies/:id/complaints/:id  (resolve / reject)
+Layout:
+  Status badge (OPEN amber / RESOLVED green / REJECTED red)
+  Title, category tag, visibility tag
+  Description
+  Horizontal image scroll — tap for full-screen modal viewer
+  Meta card: raised by (admin only), date raised
+  Resolved card (green): resolved by + date (if RESOLVED)
+  Rejected card (red): rejection reason text (if REJECTED)
+  Bottom action bar (only when OPEN and user can act):
+    Resident (own complaint): Mark Resolved button
+    Admin: Mark Resolved + Reject buttons
+    RESOLVED / REJECTED: no action bar
+Resolve flow: confirmation sheet → PATCH { status: "RESOLVED" }
+Reject flow (admin): bottom sheet with 4 predefined reasons
+  + "Other" option shows free-text input
+  → PATCH { status: "REJECTED", rejectionReason: "..." }
 
 ### Phase 2 — Member Management
 
@@ -346,6 +410,9 @@ AddNode
 InviteMember
 MemberList
 MemberDetail
+ComplaintList   → { societyId }
+RaiseComplaint  → { societyId }
+ComplaintDetail → { societyId, complaintId, title }
 
 ---
 
@@ -353,16 +420,19 @@ MemberDetail
 
 Builder:
 Can see: everything
-Dashboard actions: Manage Structure, Invite Member, View Members
+Dashboard actions: Manage Structure, Invite Member, View Members, Complaints
 Extra: Create Society
 
 Admin:
-Dashboard actions: Manage Structure, Invite Member, View Members
+Dashboard actions: Manage Structure, Invite Member, View Members, Complaints
 Cannot: Create Society, Reactivate members
 
 Resident:
-Dashboard: limited view
+Dashboard actions: Complaints (complaint.create or complaint.view_own permission)
 Cannot: see member list, manage structure, invite
+
+Dashboard Complaints action is shown if user has complaint.create OR complaint.view_own permission.
+Residents and co-residents have complaint.create; admins/builders see it via member.view check.
 
 Gatekeeper:
 Only gate-related features (future)

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,8 @@
         "@react-navigation/native-stack": "^7.14.10",
         "axios": "^1.14.0",
         "expo": "~54.0.33",
+        "expo-image-picker": "~17.0.10",
+        "expo-notifications": "~0.32.16",
         "expo-secure-store": "~15.0.8",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
@@ -3782,6 +3784,12 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@ide/backoff": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ide/backoff/-/backoff-1.0.0.tgz",
+      "integrity": "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==",
+      "license": "MIT"
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -6406,6 +6414,19 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -6432,7 +6453,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
       "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -6676,6 +6696,12 @@
       "peerDependencies": {
         "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
+    },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -6937,7 +6963,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
       "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -7797,7 +7822,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -7824,7 +7848,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -8894,6 +8917,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-7.0.8.tgz",
+      "integrity": "sha512-qFGyxk7VJbrNOQWBbE09XUuGuvkOgFS9QfToaK2FdagM2aQ+x3CvGV2DuVgl/l4ZxPgIf3b/MNh9xHpwSwn74Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "12.0.12",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
@@ -8945,6 +8977,27 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "17.0.10",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-17.0.10.tgz",
+      "integrity": "sha512-a2xrowp2trmvXyUWgX3O6Q2rZaa2C59AqivKI7+bm+wLvMfTEbZgldLX4rEJJhM8xtmEDTNU+lzjtObwzBRGaw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {
@@ -9000,6 +9053,26 @@
         "invariant": "^2.2.4"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "0.32.16",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-0.32.16.tgz",
+      "integrity": "sha512-QQD/UA6v7LgvwIJ+tS7tSvqJZkdp0nCSj9MxsDk/jU1GttYdK49/5L2LvE/4U0H7sNBz1NZAyhDZozg8xgBLXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.8",
+        "@ide/backoff": "^1.0.0",
+        "abort-controller": "^3.0.0",
+        "assert": "^2.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~7.0.8",
+        "expo-constants": "~18.0.13"
+      },
+      "peerDependencies": {
+        "expo": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -9376,7 +9449,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
       "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -9551,7 +9623,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
       "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9844,7 +9915,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -10191,6 +10261,22 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -10286,7 +10372,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10416,7 +10501,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
       "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.4",
@@ -10451,6 +10535,22 @@
       "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -10507,7 +10607,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
       "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10603,7 +10702,6 @@
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
       "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -13516,11 +13614,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13530,7 +13643,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
       "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -14150,7 +14262,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -15564,7 +15675,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
       "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -15660,7 +15770,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -17414,6 +17523,19 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -17644,7 +17766,6 @@
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
       "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",


### PR DESCRIPTION
- expo-notifications installed — device token registered after login
- expo-image-picker installed — image selection in raise complaint
- ComplaintListScreen — filtered list, resident/admin views
- RaiseComplaintScreen — full form with category picker, visibility toggle, image upload
- ComplaintDetailScreen — full detail, resolve/reject flows, image viewer
- complaints.ts service — all API calls typed
- complaintMeta.ts — category labels, icons, status colors
- Dashboard updated — Complaints action row added
- AppNavigator updated — complaint routes added