### PR TITLE
feat: unit assignment — ownership, occupancy, My Home

### DIFF
--- a/apps/api/prisma/migrations/20260413062916_add_unit_assignment/migration.sql
+++ b/apps/api/prisma/migrations/20260413062916_add_unit_assignment/migration.sql
@@ -1,0 +1,25 @@
+-- Step 1: Update OccupancyType enum
+CREATE TYPE "OccupancyType_new" AS ENUM ('OWNER_RESIDENT', 'TENANT', 'FAMILY', 'CARETAKER');
+ALTER TABLE "unit_occupancies" ALTER COLUMN "occupancyType" TYPE "OccupancyType_new" USING ("occupancyType"::text::"OccupancyType_new");
+ALTER TYPE "OccupancyType" RENAME TO "OccupancyType_old";
+ALTER TYPE "OccupancyType_new" RENAME TO "OccupancyType";
+DROP TYPE "OccupancyType_old";
+
+-- Step 2: Update OwnershipType enum
+CREATE TYPE "OwnershipType_new" AS ENUM ('PRIMARY_OWNER', 'CO_OWNER');
+ALTER TABLE "unit_ownerships" ALTER COLUMN "ownershipType" TYPE "OwnershipType_new" USING ("ownershipType"::text::"OwnershipType_new");
+ALTER TYPE "OwnershipType" RENAME TO "OwnershipType_old";
+ALTER TYPE "OwnershipType_new" RENAME TO "OwnershipType";
+DROP TYPE "OwnershipType_old";
+
+-- Step 3: Alter unit_ownerships table
+ALTER TABLE "unit_ownerships"
+ADD COLUMN "isPrimary" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN "orgId" TEXT NOT NULL DEFAULT '',
+ALTER COLUMN "ownedFrom" SET DEFAULT CURRENT_TIMESTAMP;
+
+ALTER TABLE "unit_ownerships" ALTER COLUMN "orgId" DROP DEFAULT;
+
+-- Step 4: Add indexes
+CREATE INDEX "unit_ownerships_orgId_unitId_idx" ON "unit_ownerships"("orgId", "unitId");
+CREATE INDEX "unit_ownerships_orgId_personId_idx" ON "unit_ownerships"("orgId", "personId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -197,25 +197,29 @@ enum NodeType {
 }
 
 model UnitOwnership {
-  id            String    @id @default(uuid())
+  id            String        @id @default(uuid())
+  orgId         String
   unitId        String
   personId      String
-  ownedFrom     DateTime
-  ownedUntil    DateTime?  // null = currently owns
+  ownedFrom     DateTime      @default(now())
+  ownedUntil    DateTime?
   ownershipType OwnershipType
+  isPrimary     Boolean       @default(false)
   transferDocRef String?
-  createdAt     DateTime  @default(now())
+  createdAt     DateTime      @default(now())
 
   unit   PropertyNode @relation(fields: [unitId], references: [id])
   person Person       @relation(fields: [personId], references: [id])
 
-  @@map("unit_ownerships")
+  @@index([orgId, unitId])
+  @@index([orgId, personId])
   @@index([unitId, ownedUntil])
+  @@map("unit_ownerships")
 }
 
 enum OwnershipType {
-  SOLE
-  JOINT
+  PRIMARY_OWNER
+  CO_OWNER
 }
 // unit records for property
 model UnitOccupancy {
@@ -238,9 +242,10 @@ model UnitOccupancy {
 enum OccupancyType {
   OWNER_RESIDENT
   TENANT
-  FAMILY_MEMBER
+  FAMILY
   CARETAKER
 }
+
 // audit records 
 model AuditLog {
   id        String   @id @default(uuid())

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -87,6 +87,10 @@ async function main() {
     { name: 'complaint.resolve_any', module: 'complaints', description: 'Resolve any complaint' },
     { name: 'complaint.reject',      module: 'complaints', description: 'Reject a complaint with reason' },
 
+    // Units
+    { name: 'unit.assign',    module: 'units', description: 'Assign ownership and occupancy to units' },
+    { name: 'unit.view_all',  module: 'units', description: 'View all units and assignments in society' },
+    { name: 'unit.view_own',  module: 'units', description: 'View own unit details' },
   ]
 
   for (const p of permissions) {
@@ -112,7 +116,8 @@ async function main() {
       'announcement.create', 'announcement.view',
       'visitor.view_live', 'visitor.view_emergency',
       'emergency.declare', 'emergency.view',
-      'role.create', 'role.assign', 'role.view'
+      'role.create', 'role.assign', 'role.view',
+      'unit.assign', 'unit.view_all'
     ],
 
     Admin: [
@@ -129,7 +134,8 @@ async function main() {
       'emergency.declare', 'emergency.view',
       'asset.create', 'asset.book', 'asset.view', 'asset.manage_booking',
       'role.create', 'role.assign', 'role.view',
-      'complaint.view_all', 'complaint.resolve_any', 'complaint.reject'
+      'complaint.view_all', 'complaint.resolve_any', 'complaint.reject',
+      'unit.assign', 'unit.view_all'
     ],
 
     Resident: [
@@ -141,7 +147,8 @@ async function main() {
       'poll.vote', 'poll.view',
       'emergency.declare', 'emergency.view',
       'asset.book', 'asset.view',
-      'co_resident.invite'
+      'co_resident.invite',
+      'unit.view_own'
     ],
 
     'Co-resident': [
@@ -152,7 +159,8 @@ async function main() {
       'service.view',
       'poll.vote', 'poll.view',
       'emergency.declare', 'emergency.view',
-      'asset.book', 'asset.view'
+      'asset.book', 'asset.view',
+      'unit.view_own'
     ],
 
     Gatekeeper: [
@@ -353,10 +361,12 @@ async function main() {
   if (arjunPerson) {
     await prisma.unitOwnership.create({
       data: {
+        orgId: org.id,
         unitId: unit4B.id,
         personId: arjunPerson.id,
         ownedFrom: new Date('2022-01-01'),
-        ownershipType: 'SOLE'
+        ownershipType: 'PRIMARY_OWNER',
+        isPrimary: true
       }
     })
 
@@ -384,7 +394,7 @@ async function main() {
         unitId: unit4B.id,
         personId: meeraPerson.id,
         occupiedFrom: new Date('2022-01-01'),
-        occupancyType: 'FAMILY_MEMBER',
+        occupancyType: 'FAMILY',
         isPrimary: false
       }
     })

--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -111,7 +111,8 @@ router.get(
           isActive:      m.isActive
         }
 
-        if (m.isActive && !occupancy) {
+        const isResidentRole = ['Resident', 'Co-resident'].includes(m.role.name)
+        if (m.isActive && !occupancy && isResidentRole) {
           pendingSetup.push(memberData)
         } else {
           active.push(memberData)

--- a/apps/api/src/routes/units.ts
+++ b/apps/api/src/routes/units.ts
@@ -1,0 +1,590 @@
+import { Router, Response } from 'express'
+import { prisma } from '../lib/prisma'
+import { authenticate, AuthRequest } from '../middleware/auth'
+import { requirePermission } from '../middleware/permission'
+import { enforceTenantContext } from '../middleware/tenantContext'
+import { sendSuccess, sendError, sendNotFound, sendServerError } from '../utils/response'
+
+const router = Router()
+
+// ─────────────────────────────────────────────
+// Helper — get personId from userId
+// ─────────────────────────────────────────────
+const getPersonId = async (userId: string): Promise<string | null> => {
+  const person = await prisma.person.findFirst({
+    where: { userId }
+  })
+  return person?.id ?? null
+}
+
+// ─────────────────────────────────────────────
+// Helper — verify node is a UNIT type
+// ─────────────────────────────────────────────
+const verifyUnit = async (nodeId: string, orgId: string) => {
+  return prisma.propertyNode.findFirst({
+    where: { id: nodeId, orgId, nodeType: 'UNIT' }
+  })
+}
+
+// ─────────────────────────────────────────────
+// Helper — verify member belongs to this society
+// ─────────────────────────────────────────────
+const verifyMember = async (userId: string, orgId: string) => {
+  const person = await prisma.person.findFirst({
+    where: { userId }
+  })
+  if (!person) return null
+
+  const membership = await prisma.membership.findFirst({
+    where: { userId, orgId, isActive: true }
+  })
+  if (!membership) return null
+
+  return { person, membership }
+}
+
+// ─────────────────────────────────────────────
+// GET /societies/:id/units
+// List all units with occupancy status
+// ─────────────────────────────────────────────
+router.get(
+  '/:id/units',
+  authenticate,
+  enforceTenantContext,
+  requirePermission('unit.view_all'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId } = req.params
+      const { status, tower } = req.query
+
+      // Get all UNIT nodes in this society
+      const whereNode: any = { orgId, nodeType: 'UNIT' }
+      if (tower) {
+        // Filter units under a specific tower
+        const towerNode = await prisma.propertyNode.findFirst({
+          where: { id: tower as string, orgId }
+        })
+        if (!towerNode) return sendError(res, 'tower_not_found', 404)
+      }
+
+      const units = await prisma.propertyNode.findMany({
+        where: whereNode,
+        include: {
+          ownerships: {
+            where: { ownedUntil: null },
+            include: { person: true },
+            orderBy: { isPrimary: 'desc' }
+          },
+          occupancies: {
+            where: { occupiedUntil: null },
+            include: { person: true },
+            orderBy: { isPrimary: 'desc' }
+          },
+          parent: {
+            include: { parent: true }
+          }
+        },
+        orderBy: { name: 'asc' }
+      })
+
+      const formatted = units.map(unit => {
+        const isVacant = unit.occupancies.length === 0
+        const primaryOwner = unit.ownerships.find(o => o.isPrimary)
+        const primaryOccupant = unit.occupancies.find(o => o.isPrimary)
+
+        // Build path
+        const path = [
+          unit.parent?.parent?.name,
+          unit.parent?.name,
+        ].filter(Boolean).join(' → ')
+
+        return {
+          id: unit.id,
+          name: unit.name,
+          code: unit.code,
+          path: path || null,
+          metadata: unit.metadata,
+          isVacant,
+          primaryOwner: primaryOwner?.person.fullName ?? null,
+          primaryOccupant: primaryOccupant?.person.fullName ?? null,
+          occupancyType: primaryOccupant?.occupancyType ?? null
+        }
+      })
+
+      // Apply vacancy filter
+      let result = formatted
+      if (status === 'vacant') result = formatted.filter(u => u.isVacant)
+      if (status === 'occupied') result = formatted.filter(u => !u.isVacant)
+
+      return sendSuccess(res, {
+        units: result,
+        total: result.length,
+        occupied: result.filter(u => !u.isVacant).length,
+        vacant: result.filter(u => u.isVacant).length
+      })
+
+    } catch (error) {
+      console.error('GET /units error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// GET /societies/:id/units/:nodeId
+// Get full details of a specific unit
+// ─────────────────────────────────────────────
+router.get(
+  '/:id/units/:nodeId',
+  authenticate,
+  enforceTenantContext,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId, nodeId } = req.params
+      const permissions = req.user!.permissions
+      const canViewAll = permissions.includes('unit.view_all')
+      const canViewOwn = permissions.includes('unit.view_own')
+
+      const unit = await prisma.propertyNode.findFirst({
+        where: { id: nodeId, orgId, nodeType: 'UNIT' },
+        include: {
+          ownerships: {
+            include: { person: true },
+            orderBy: [{ isPrimary: 'desc' }, { ownedFrom: 'asc' }]
+          },
+          occupancies: {
+            include: { person: true },
+            orderBy: [{ isPrimary: 'desc' }, { occupiedFrom: 'asc' }]
+          },
+          parent: {
+            include: { parent: true }
+          }
+        }
+      })
+
+      if (!unit) return sendNotFound(res, 'unit_not_found')
+
+      // Residents can only view their own unit
+      if (!canViewAll && canViewOwn) {
+        const personId = await getPersonId(req.user!.userId)
+        const isOwnUnit = unit.occupancies.some(
+          o => o.personId === personId && o.occupiedUntil === null
+        ) || unit.ownerships.some(
+          o => o.personId === personId && o.ownedUntil === null
+        )
+        if (!isOwnUnit) {
+          return sendError(res, 'insufficient_permissions', 403)
+        }
+      }
+
+      const path = [
+        unit.parent?.parent?.name,
+        unit.parent?.name,
+      ].filter(Boolean).join(' → ')
+
+      const meta = unit.metadata as any ?? {}
+
+      const activeOwnerships = unit.ownerships.filter(o => !o.ownedUntil)
+      const activeOccupants = unit.occupancies.filter(o => !o.occupiedUntil)
+      const pastOccupants = unit.occupancies.filter(o => o.occupiedUntil)
+
+      return sendSuccess(res, {
+        id: unit.id,
+        name: unit.name,
+        code: unit.code,
+        path,
+        floor: meta.floorNo ?? null,
+        bhk: meta.bhk ?? null,
+        area: meta.sqFt ?? null,
+        isVacant: activeOccupants.length === 0,
+        owners: activeOwnerships.map(o => ({
+          id: o.id,
+          name: o.person.fullName,
+          phone: o.person.phone,
+          ownershipType: o.ownershipType,
+          isPrimary: o.isPrimary,
+          ownedFrom: o.ownedFrom
+        })),
+        currentOccupants: activeOccupants.map(o => ({
+          id: o.id,
+          name: o.person.fullName,
+          phone: o.person.phone,
+          occupancyType: o.occupancyType,
+          isPrimary: o.isPrimary,
+          occupiedFrom: o.occupiedFrom
+        })),
+        occupancyHistory: pastOccupants.map(o => ({
+          name: o.person.fullName,
+          occupancyType: o.occupancyType,
+          occupiedFrom: o.occupiedFrom,
+          occupiedUntil: o.occupiedUntil
+        }))
+      })
+
+    } catch (error) {
+      console.error('GET /units/:nodeId error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// POST /societies/:id/units/:nodeId/ownership
+// Assign ownership of a unit to a member
+// ─────────────────────────────────────────────
+router.post(
+  '/:id/units/:nodeId/ownership',
+  authenticate,
+  enforceTenantContext,
+  requirePermission('unit.assign'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId, nodeId } = req.params
+      const { userId, ownershipType, isPrimary = false } = req.body
+
+      if (!userId || !ownershipType) {
+        return sendError(res, 'missing_field', 400, {
+          field: !userId ? 'userId' : 'ownershipType'
+        })
+      }
+
+      const validTypes = ['PRIMARY_OWNER', 'CO_OWNER']
+      if (!validTypes.includes(ownershipType)) {
+        return sendError(res, 'invalid_ownership_type', 400)
+      }
+
+      // Verify it's a UNIT node
+      const unit = await verifyUnit(nodeId, orgId)
+      if (!unit) return sendError(res, 'not_a_unit', 400)
+
+      // Verify member belongs to this society
+      const memberData = await verifyMember(userId, orgId)
+      if (!memberData) return sendNotFound(res, 'member_not_found')
+
+      const { person } = memberData
+
+      // Check if already has primary owner
+      if (isPrimary) {
+        const existingPrimary = await prisma.unitOwnership.findFirst({
+          where: { unitId: nodeId, isPrimary: true, ownedUntil: null }
+        })
+        if (existingPrimary) {
+          return sendError(res, 'already_has_primary', 400, {
+            message: 'This unit already has a primary owner. End existing ownership first or use CO_OWNER.'
+          })
+        }
+      }
+
+      // Create ownership record
+      const ownership = await prisma.unitOwnership.create({
+        data: {
+          orgId,
+          unitId: nodeId,
+          personId: person.id,
+          ownershipType,
+          isPrimary,
+          ownedFrom: new Date()
+        }
+      })
+
+      return sendSuccess(res, {
+        id: ownership.id,
+        flatName: unit.name,
+        member: {
+          name: person.fullName,
+          phone: person.phone
+        },
+        ownershipType: ownership.ownershipType,
+        isPrimary: ownership.isPrimary,
+        ownedFrom: ownership.ownedFrom
+      }, 201)
+
+    } catch (error) {
+      console.error('POST /ownership error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// DELETE /societies/:id/units/:nodeId/ownership/:ownershipId
+// End ownership
+// ─────────────────────────────────────────────
+router.delete(
+  '/:id/units/:nodeId/ownership/:ownershipId',
+  authenticate,
+  enforceTenantContext,
+  requirePermission('unit.assign'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId, ownershipId } = req.params
+
+      const ownership = await prisma.unitOwnership.findFirst({
+        where: { id: ownershipId, orgId }
+      })
+
+      if (!ownership) return sendNotFound(res, 'ownership_not_found')
+      if (ownership.ownedUntil) return sendError(res, 'already_ended', 400)
+
+      const updated = await prisma.unitOwnership.update({
+        where: { id: ownershipId },
+        data: { ownedUntil: new Date() }
+      })
+
+      return sendSuccess(res, {
+        message: 'ownership_ended',
+        ownedUntil: updated.ownedUntil
+      })
+
+    } catch (error) {
+      console.error('DELETE /ownership error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// POST /societies/:id/units/:nodeId/occupancy
+// Assign occupancy of a unit to a member
+// ─────────────────────────────────────────────
+router.post(
+  '/:id/units/:nodeId/occupancy',
+  authenticate,
+  enforceTenantContext,
+  requirePermission('unit.assign'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId, nodeId } = req.params
+      const { userId, occupancyType, isPrimary = false } = req.body
+
+      if (!userId || !occupancyType) {
+        return sendError(res, 'missing_field', 400, {
+          field: !userId ? 'userId' : 'occupancyType'
+        })
+      }
+
+      const validTypes = ['OWNER_RESIDENT', 'TENANT', 'FAMILY', 'CARETAKER']
+      if (!validTypes.includes(occupancyType)) {
+        return sendError(res, 'invalid_occupancy_type', 400)
+      }
+
+      // Verify it's a UNIT node
+      const unit = await verifyUnit(nodeId, orgId)
+      if (!unit) return sendError(res, 'not_a_unit', 400)
+
+      // Verify member belongs to this society
+      const memberData = await verifyMember(userId, orgId)
+      if (!memberData) return sendNotFound(res, 'member_not_found')
+
+      const { person } = memberData
+
+      // Check if already has primary occupant
+      if (isPrimary) {
+        const existingPrimary = await prisma.unitOccupancy.findFirst({
+          where: { unitId: nodeId, isPrimary: true, occupiedUntil: null }
+        })
+        if (existingPrimary) {
+          return sendError(res, 'already_has_primary', 400, {
+            message: 'This unit already has a primary occupant.'
+          })
+        }
+      }
+
+      // Check if member already occupying this unit
+      const existingOccupancy = await prisma.unitOccupancy.findFirst({
+        where: {
+          unitId: nodeId,
+          personId: person.id,
+          occupiedUntil: null
+        }
+      })
+      if (existingOccupancy) {
+        return sendError(res, 'already_occupying', 400)
+      }
+
+      const occupancy = await prisma.unitOccupancy.create({
+        data: {
+          unitId: nodeId,
+          personId: person.id,
+          occupancyType,
+          isPrimary,
+          occupiedFrom: new Date()
+        }
+      })
+
+      return sendSuccess(res, {
+        id: occupancy.id,
+        flatName: unit.name,
+        member: {
+          name: person.fullName,
+          phone: person.phone
+        },
+        occupancyType: occupancy.occupancyType,
+        isPrimary: occupancy.isPrimary,
+        occupiedFrom: occupancy.occupiedFrom
+      }, 201)
+
+    } catch (error) {
+      console.error('POST /occupancy error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// DELETE /societies/:id/units/:nodeId/occupancy/:occupancyId
+// End occupancy
+// ─────────────────────────────────────────────
+router.delete(
+  '/:id/units/:nodeId/occupancy/:occupancyId',
+  authenticate,
+  enforceTenantContext,
+  requirePermission('unit.assign'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId, occupancyId } = req.params
+
+      const occupancy = await prisma.unitOccupancy.findFirst({
+        where: { id: occupancyId },
+        include: {
+          unit: true
+        }
+      })
+
+      if (!occupancy || occupancy.unit.orgId !== orgId) {
+        return sendNotFound(res, 'occupancy_not_found')
+      }
+      if (occupancy.occupiedUntil) {
+        return sendError(res, 'already_ended', 400)
+      }
+
+      const updated = await prisma.unitOccupancy.update({
+        where: { id: occupancyId },
+        data: { occupiedUntil: new Date() }
+      })
+
+      return sendSuccess(res, {
+        message: 'occupancy_ended',
+        occupiedUntil: updated.occupiedUntil
+      })
+
+    } catch (error) {
+      console.error('DELETE /occupancy error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// GET /societies/:id/members/:memberId/units
+// Get all units linked to a member (My Home)
+// ─────────────────────────────────────────────
+router.get(
+  '/:id/members/:memberId/units',
+  authenticate,
+  enforceTenantContext,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const { id: orgId, memberId } = req.params
+      const permissions = req.user!.permissions
+      const canViewAll = permissions.includes('unit.view_all')
+      const canViewOwn = permissions.includes('unit.view_own')
+
+      // Get the membership to find the userId
+      const membership = await prisma.membership.findFirst({
+        where: { id: memberId, orgId, isActive: true }
+      })
+      if (!membership) return sendNotFound(res, 'member_not_found')
+
+      // Residents can only view their own units
+      if (!canViewAll && canViewOwn) {
+        if (membership.userId !== req.user!.userId) {
+          return sendError(res, 'insufficient_permissions', 403)
+        }
+      }
+
+      if (!canViewAll && !canViewOwn) {
+        return sendError(res, 'insufficient_permissions', 403)
+      }
+
+      const person = await prisma.person.findFirst({
+        where: { userId: membership.userId }
+      })
+      if (!person) return sendNotFound(res, 'member_not_found')
+
+      // Get all ownerships
+      const ownerships = await prisma.unitOwnership.findMany({
+        where: { personId: person.id, ownedUntil: null },
+        include: {
+          unit: {
+            include: {
+              parent: { include: { parent: true } },
+              ownerships: {
+                where: { ownedUntil: null },
+                include: { person: true }
+              }
+            }
+          }
+        }
+      })
+
+      // Get all occupancies
+      const occupancies = await prisma.unitOccupancy.findMany({
+        where: { personId: person.id, occupiedUntil: null },
+        include: {
+          unit: {
+            include: {
+              parent: { include: { parent: true } },
+              occupancies: {
+                where: { occupiedUntil: null },
+                include: { person: true }
+              }
+            }
+          }
+        }
+      })
+
+      const formatPath = (unit: any) => [
+        unit.parent?.parent?.name,
+        unit.parent?.name
+      ].filter(Boolean).join(' → ')
+
+      return sendSuccess(res, {
+        ownerships: ownerships.map(o => ({
+          flatId: o.unit.id,
+          flatName: o.unit.name,
+          path: formatPath(o.unit),
+          ownershipType: o.ownershipType,
+          isPrimary: o.isPrimary,
+          ownedFrom: o.ownedFrom,
+          coOwners: o.unit.ownerships
+            .filter(ow => ow.personId !== person.id)
+            .map(ow => ({
+              name: ow.person.fullName,
+              ownershipType: ow.ownershipType
+            }))
+        })),
+        occupancies: occupancies.map(o => ({
+          flatId: o.unit.id,
+          flatName: o.unit.name,
+          path: formatPath(o.unit),
+          occupancyType: o.occupancyType,
+          isPrimary: o.isPrimary,
+          occupiedFrom: o.occupiedFrom,
+          coOccupants: o.unit.occupancies
+            .filter(oc => oc.personId !== person.id)
+            .map(oc => ({
+              name: oc.person.fullName,
+              occupancyType: oc.occupancyType
+            }))
+        }))
+      })
+
+    } catch (error) {
+      console.error('GET /members/:id/units error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
+export default router

--- a/docs/API.md
+++ b/docs/API.md
@@ -1187,3 +1187,261 @@ Update complaint status.
 403 cannot_resolve_others     → resident resolving others' complaint
 404 complaint_not_found       → complaint not found
 401 no_token                  → not logged in
+
+## Unit Assignment
+
+### GET /api/societies/:id/units
+List all units with occupancy status.
+
+**Auth:** Required
+**Permission:** unit.view_all
+
+**Query params:**
+- `status` — `vacant` | `occupied` | `all` (default: all)
+
+**Response 200:**
+```json
+{
+  "data": {
+    "units": [
+      {
+        "id": "uuid",
+        "name": "Flat 4B",
+        "code": "4B",
+        "path": "Tower A → Wing 1",
+        "metadata": {},
+        "isVacant": false,
+        "primaryOwner": "Arjun Mehta",
+        "primaryOccupant": "Arjun Mehta",
+        "occupancyType": "OWNER_RESIDENT"
+      }
+    ],
+    "total": 48,
+    "occupied": 36,
+    "vacant": 12
+  }
+}
+```
+
+---
+
+### GET /api/societies/:id/units/:nodeId
+Get full unit detail — owners, occupants, history.
+
+**Auth:** Required
+**Permission:** unit.view_all OR unit.view_own (own flat only)
+
+**Response 200:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "name": "Flat 4B",
+    "code": "4B",
+    "path": "Tower A → Wing 1",
+    "floor": 4,
+    "bhk": "2BHK",
+    "area": 950,
+    "isVacant": false,
+    "owners": [
+      {
+        "id": "uuid",
+        "name": "Arjun Mehta",
+        "phone": "+919222222222",
+        "ownershipType": "PRIMARY_OWNER",
+        "isPrimary": true,
+        "ownedFrom": "datetime"
+      }
+    ],
+    "currentOccupants": [
+      {
+        "id": "uuid",
+        "name": "Arjun Mehta",
+        "phone": "+919222222222",
+        "occupancyType": "OWNER_RESIDENT",
+        "isPrimary": true,
+        "occupiedFrom": "datetime"
+      }
+    ],
+    "occupancyHistory": [
+      {
+        "name": "Priya Shah",
+        "occupancyType": "TENANT",
+        "occupiedFrom": "datetime",
+        "occupiedUntil": "datetime"
+      }
+    ]
+  }
+}
+```
+
+---
+
+### POST /api/societies/:id/units/:nodeId/ownership
+Assign ownership of a unit to a member.
+
+**Auth:** Required
+**Permission:** unit.assign
+
+**Request:**
+```json
+{
+  "userId": "uuid",
+  "ownershipType": "PRIMARY_OWNER",
+  "isPrimary": true
+}
+```
+
+**Ownership types:** PRIMARY_OWNER, CO_OWNER
+
+**Response 201:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "flatName": "Flat 4B",
+    "member": { "name": "Arjun Mehta", "phone": "+919222222222" },
+    "ownershipType": "PRIMARY_OWNER",
+    "isPrimary": true,
+    "ownedFrom": "datetime"
+  }
+}
+```
+
+**Errors:**
+400 missing_field          → userId or ownershipType missing
+400 invalid_ownership_type → not PRIMARY_OWNER or CO_OWNER
+400 not_a_unit             → nodeId is not a UNIT type node
+400 already_has_primary    → flat already has a primary owner
+404 node_not_found         → flat not found in this society
+404 member_not_found       → userId not a member of this society
+403 insufficient_permissions
+
+---
+
+### DELETE /api/societies/:id/units/:nodeId/ownership/:ownershipId
+End ownership (sets ownedUntil = today).
+
+**Auth:** Required
+**Permission:** unit.assign
+
+**Response 200:**
+```json
+{
+  "data": {
+    "message": "ownership_ended",
+    "ownedUntil": "datetime"
+  }
+}
+```
+
+**Errors:**
+400 already_ended       → ownership already ended
+404 ownership_not_found → record not found
+
+---
+
+### POST /api/societies/:id/units/:nodeId/occupancy
+Assign occupancy of a unit to a member.
+
+**Auth:** Required
+**Permission:** unit.assign
+
+**Request:**
+```json
+{
+  "userId": "uuid",
+  "occupancyType": "OWNER_RESIDENT",
+  "isPrimary": true
+}
+```
+
+**Occupancy types:** OWNER_RESIDENT, TENANT, FAMILY, CARETAKER
+
+**Response 201:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "flatName": "Flat 4B",
+    "member": { "name": "Arjun Mehta", "phone": "+919222222222" },
+    "occupancyType": "OWNER_RESIDENT",
+    "isPrimary": true,
+    "occupiedFrom": "datetime"
+  }
+}
+```
+
+**Errors:**
+400 missing_field          → userId or occupancyType missing
+400 invalid_occupancy_type → not a valid occupancy type
+400 not_a_unit             → nodeId is not a UNIT type node
+400 already_has_primary    → flat already has a primary occupant
+400 already_occupying      → member already occupying this flat
+404 node_not_found
+404 member_not_found
+403 insufficient_permissions
+
+---
+
+### DELETE /api/societies/:id/units/:nodeId/occupancy/:occupancyId
+End occupancy (sets occupiedUntil = today).
+
+**Auth:** Required
+**Permission:** unit.assign
+
+**Response 200:**
+```json
+{
+  "data": {
+    "message": "occupancy_ended",
+    "occupiedUntil": "datetime"
+  }
+}
+```
+
+**Errors:**
+400 already_ended        → occupancy already ended
+404 occupancy_not_found  → record not found
+
+---
+
+### GET /api/societies/:id/members/:memberId/units
+Get all units linked to a member. Used for My Home screen.
+
+**Auth:** Required
+**Permission:** unit.view_all OR unit.view_own (own membership only)
+
+**Response 200:**
+```json
+{
+  "data": {
+    "ownerships": [
+      {
+        "flatId": "uuid",
+        "flatName": "Flat 4B",
+        "path": "Tower A → Wing 1",
+        "ownershipType": "PRIMARY_OWNER",
+        "isPrimary": true,
+        "ownedFrom": "datetime",
+        "coOwners": [
+          { "name": "Meera Mehta", "ownershipType": "CO_OWNER" }
+        ]
+      }
+    ],
+    "occupancies": [
+      {
+        "flatId": "uuid",
+        "flatName": "Flat 4B",
+        "path": "Tower A → Wing 1",
+        "occupancyType": "OWNER_RESIDENT",
+        "isPrimary": true,
+        "occupiedFrom": "datetime",
+        "coOccupants": [
+          { "name": "Meera Mehta", "occupancyType": "FAMILY" }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -243,3 +243,45 @@ Notifications work correctly in production builds.
 Reason: Expo SDK 53 removed push notification support
 from Expo Go. Development build required for full testing.
 Will test when EAS build is set up.
+
+## 024 — ownedUntil added now for V2 readiness
+**Date:** 2026-04-13
+**Decision:** Add ownedUntil to unit_ownerships now even though
+ownership transfer UI is V2.
+**Reason:** Adding field later requires migration. Adding now
+costs nothing. Enables full ownership history from day one.
+
+## 025 — Ownership and occupancy are separate records
+**Date:** 2026-04-13
+**Decision:** Owner and occupant tracked independently.
+One person can own a flat but not live there.
+**Reason:** Reflects real Indian society reality — builder-owned
+rentals, tenant arrangements, and investment properties are common.
+
+## 026 — Deactivate does not end occupancy
+**Date:** 2026-04-13
+**Decision:** Deactivating a member removes app access only.
+Occupancy record untouched. Only explicit moveout ends occupancy.
+**Reason:** Deactivation is an app concern. Physical occupancy
+is a real world fact. These are independent concepts.
+
+## 027 — Multiple owners and occupants per flat
+**Date:** 2026-04-13
+**Decision:** No hard limit on ownership or occupancy records
+per flat. One marked isPrimary for display purposes.
+**Reason:** Joint ownership and family arrangements are standard
+in Indian residential societies.
+
+## 028 — Builder treated as any other owner
+**Date:** 2026-04-13
+**Decision:** Builder ownership recorded same as any member.
+No special UI treatment for builder-owned flats.
+**Reason:** Keeps architecture consistent. Admin can see all
+flats regardless of who owns them.
+
+## 029 — My Home shows primary flat on dashboard
+**Date:** 2026-04-13
+**Decision:** Dashboard shows primary flat details only.
+Full My Home screen shows all linked flats.
+**Reason:** Dashboard must stay clean. Members with multiple
+flats get full detail in My Home screen.

--- a/docs/MOBILE_CONTEXT.md
+++ b/docs/MOBILE_CONTEXT.md
@@ -319,6 +319,33 @@ Role options: Admin, Resident, Gatekeeper, Co-resident
 Shows pending invitations list below form
 Wireframe: approved ✓
 
+### AssignUnitScreen
+Triggered from MemberDetailScreen for Admin/Builder.
+- Shows structure tree of all UNIT nodes
+- Admin picks a flat
+- Chooses ownershipType and occupancyType
+- POST /societies/:id/units/:nodeId/ownership
+- POST /societies/:id/units/:nodeId/occupancy
+
+### UnitDetailScreen
+Triggered from StructureScreen when tapping a UNIT node.
+- Shows owners, current occupants, occupancy history
+- Add/end ownership and occupancy
+- GET /societies/:id/units/:nodeId
+
+### UnitInventoryScreen
+Admin/Builder view of all flats.
+- Filter: All / Occupied / Vacant
+- GET /societies/:id/units
+
+### MyHomeScreen
+Resident/Co-resident view of own flat.
+- Flat name, path, BHK, floor, area
+- Ownership type
+- Co-owners and co-occupants
+- Occupancy history
+- GET /societies/:id/members/:memberId/units
+
 ### Complaint Screens
 
 **Screen: ComplaintListScreen**

--- a/docs/briefs/unit-assignment.md
+++ b/docs/briefs/unit-assignment.md
@@ -1,0 +1,721 @@
+# Feature Brief: Unit Assignment
+
+## Status
+Planned
+
+## Priority
+High — completes the core resident experience.
+Without this every member shows "Pending Setup"
+and no resident is linked to a flat.
+This is the missing link between society structure
+and member management.
+
+---
+
+## Overview
+
+Two distinct concepts managed together:
+
+**Ownership** — who owns the flat legally.
+  Arjun owns Flat 4B.
+  Recorded permanently. Changes only on sale.
+
+**Occupancy** — who is currently living in the flat.
+  Arjun lives in Flat 4B (owner-resident).
+  OR Priya lives there as tenant.
+  Changes when people move in or move out.
+
+Both can have multiple people simultaneously.
+Both are tracked with full history.
+
+---
+
+## Who Uses It
+
+Builder — assign ownership and occupancy.
+          View all flats, ownership, occupancy.
+          Track vacant flats.
+
+Admin — same as Builder for day-to-day operations.
+        RWA secretary typically handles this.
+
+Resident — view their own flat(s).
+           See co-owners and co-occupants.
+           Cannot assign anything.
+
+Co-resident — same view as Resident (own flat only).
+
+Gatekeeper — no access.
+
+---
+
+## Real World Scenarios
+
+### Scenario 1 — Builder hands over flat to owner
+Builder creates society, sets up Tower A → Flat 4B.
+Builder invites Arjun as Resident.
+Arjun accepts → becomes member.
+Admin links Arjun to Flat 4B:
+Ownership: PRIMARY_OWNER
+Occupancy: OWNER_RESIDENT, isPrimary
+Arjun now shows: Flat 4B · Owner · Resident
+Moves from Pending Setup → Active.
+
+### Scenario 2 — Builder rents flat directly
+Builder keeps Flat 5C and rents to Priya.
+Builder invites Priya as Resident.
+Admin links:
+Ownership: Builder → Flat 5C, PRIMARY_OWNER
+Occupancy: Priya → Flat 5C, TENANT, isPrimary
+Builder owns it. Priya lives in it.
+Both records coexist on same flat.
+
+### Scenario 3 — Joint ownership
+Arjun and Meera jointly own Flat 4B.
+Admin links:
+Arjun → Flat 4B, PRIMARY_OWNER
+Meera → Flat 4B, CO_OWNER
+Both show as owners of same flat.
+
+### Scenario 4 — Owner + family living together
+Arjun owns and lives in Flat 4B.
+His wife Meera (Co-resident) also lives there.
+Admin links:
+Arjun → Flat 4B, OWNER_RESIDENT, isPrimary
+Meera → Flat 4B, FAMILY, isPrimary=false
+Both linked to same flat.
+
+### Scenario 5 — Tenant in owner's flat
+Arjun owns Flat 4B but doesn't live there.
+He rents it to Priya.
+Admin links:
+Ownership: Arjun → Flat 4B, PRIMARY_OWNER
+Occupancy: Priya → Flat 5B, TENANT, isPrimary
+Arjun is owner. Priya is occupant. Different people.
+
+### Scenario 6 — Same person owns multiple flats
+Arjun owns Flat 4B and Flat 5C as investments.
+Two ownership records — both pointing to Arjun.
+My Home screen shows both flats.
+Dashboard shows primary flat.
+
+### Scenario 7 — Member moves out
+Priya moves out of Flat 4B.
+Admin marks Priya as moved out (already built).
+Her occupancy record: occupiedUntil = today.
+Flat 4B becomes vacant.
+Vacant flat appears in inventory view.
+
+### Scenario 8 — Ownership ends (V2 UI, field exists now)
+Arjun sells Flat 4B to new person.
+Admin ends Arjun's ownership: ownedUntil = today.
+New owner invited and linked.
+Full history preserved.
+
+---
+
+## What It Does NOT Do
+
+- No ownership transfer UI (V2 — field exists in schema now)
+- No non-app owner records (V1 — all via memberships)
+- No bulk assignment (V2)
+- No ownership documents or legal records
+- No maintenance charge calculation
+- No payment tracking
+
+---
+
+## Occupancy Types — Final
+OWNER_RESIDENT  → owns the flat, lives there
+TENANT          → renting, living there
+FAMILY          → family member of owner/tenant
+CARETAKER       → domestic staff living on premises
+
+## Ownership Types — Final
+PRIMARY_OWNER   → main legal owner of flat
+CO_OWNER        → joint owner (equal rights)
+
+---
+
+## Status Rules
+Member status (in member list):
+Active:
+Has active membership (isActive = true)
+AND has at least one active occupancy
+→ Shows flat name and occupancy type
+Pending Setup:
+Has active membership
+BUT no active occupancy assigned yet
+→ Shows "No unit assigned"
+Inactive:
+isActive = false
+→ Does not appear in active list
+
+---
+
+## Vacant Flat Definition
+A flat (property node of type UNIT) is vacant when:
+No active occupancy exists for it
+(no unit_occupancy row where orgId matches
+AND nodeId matches
+AND occupiedUntil IS NULL)
+Vacant flats visible to: Admin, Builder only.
+
+---
+
+## My Home Screen — Resident View
+Triggered from Dashboard:
+"My Home" action → only if resident
+has at least one active occupancy
+Screen shows:
+Primary flat details:
+Name (e.g. Flat 4B)
+Tower/Wing path (e.g. Tower A → Wing 1)
+BHK, Floor, Area (from node metadata)
+Occupancy type (Owner-Resident / Tenant / Family)
+Co-owners of this flat:
+List of all owners (from unit_ownerships)
+Their name, ownership type
+Co-occupants of this flat:
+List of all current occupants
+Their name, occupancy type
+Excluding self
+Occupancy history:
+All past occupancies for this flat
+Name, type, from date, until date
+If member has multiple flats:
+Dashboard shows primary flat
+My Home screen shows all flats with tab/list
+
+---
+
+## Database Changes
+
+### Update unit_ownerships table
+
+Add ownedUntil field (industry-grade — enables history):
+
+```sql
+ALTER TABLE unit_ownerships
+ADD COLUMN owned_until TIMESTAMP;
+```
+
+No other changes needed to ownership table.
+
+### New enum values in schema
+
+```prisma
+enum OwnershipType {
+  PRIMARY_OWNER
+  CO_OWNER
+}
+
+enum OccupancyType {
+  OWNER_RESIDENT
+  TENANT
+  FAMILY
+  CARETAKER
+}
+```
+
+### Indexes needed
+unit_ownerships:
+(orgId, nodeId) → fetch owners of a flat
+(orgId, userId) → fetch flats owned by a person
+(orgId, nodeId, ownedUntil) → active owners only
+unit_occupancies:
+(orgId, nodeId) → fetch occupants of a flat
+(orgId, userId) → fetch flats occupied by a person
+(orgId, nodeId, occupiedUntil) → active occupants only
+(orgId, occupiedUntil) → all vacant flat detection
+
+---
+
+## Permissions Needed
+New permissions:
+unit.assign        → assign ownership or occupancy
+unit.view_all      → view all flats and assignments
+unit.view_own      → view own flat details only
+Role bundles:
+Builder → unit.assign, unit.view_all
+Admin   → unit.assign, unit.view_all
+Resident → unit.view_own
+Co-resident → unit.view_own
+Gatekeeper → none
+
+---
+
+## API Endpoints
+
+### POST /societies/:id/units/:nodeId/ownership
+Assign ownership of a flat to a member.
+
+**Auth:** Required
+**Permission:** unit.assign
+
+**Request:**
+```json
+{
+  "userId": "uuid",
+  "ownershipType": "PRIMARY_OWNER",
+  "isPrimary": true
+}
+```
+
+**Response 201:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "flatName": "Flat 4B",
+    "member": {
+      "name": "Arjun Mehta",
+      "phone": "+919222222222"
+    },
+    "ownershipType": "PRIMARY_OWNER",
+    "isPrimary": true,
+    "ownedFrom": "datetime"
+  }
+}
+```
+
+**Errors:**
+400 missing_field         → userId or ownershipType missing
+400 invalid_ownership_type → not PRIMARY_OWNER or CO_OWNER
+400 not_a_unit            → nodeId is not a UNIT type node
+400 already_has_primary   → flat already has primary owner
+and isPrimary: true sent again
+404 node_not_found        → flat doesn't exist in this society
+404 member_not_found      → userId not a member of this society
+403 insufficient_permissions
+
+---
+
+### DELETE /societies/:id/units/:nodeId/ownership/:ownershipId
+End ownership (mark ownedUntil = today).
+
+**Auth:** Required
+**Permission:** unit.assign
+
+**Response 200:**
+```json
+{
+  "data": {
+    "message": "ownership_ended",
+    "ownedUntil": "datetime"
+  }
+}
+```
+
+**Errors:**
+404 ownership_not_found → ownership record not found
+400 already_ended       → ownership already ended
+
+---
+
+### POST /societies/:id/units/:nodeId/occupancy
+Assign occupancy of a flat to a member.
+
+**Auth:** Required
+**Permission:** unit.assign
+
+**Request:**
+```json
+{
+  "userId": "uuid",
+  "occupancyType": "OWNER_RESIDENT",
+  "isPrimary": true
+}
+```
+
+**Response 201:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "flatName": "Flat 4B",
+    "member": {
+      "name": "Arjun Mehta",
+      "phone": "+919222222222"
+    },
+    "occupancyType": "OWNER_RESIDENT",
+    "isPrimary": true,
+    "occupiedFrom": "datetime"
+  }
+}
+```
+
+**Errors:**
+400 missing_field          → userId or occupancyType missing
+400 invalid_occupancy_type → not a valid occupancy type
+400 not_a_unit             → nodeId is not UNIT type
+400 already_has_primary    → flat already has primary occupant
+and isPrimary: true sent again
+400 already_occupying      → member already has active occupancy
+in this flat
+404 node_not_found
+404 member_not_found
+403 insufficient_permissions
+
+---
+
+### DELETE /societies/:id/units/:nodeId/occupancy/:occupancyId
+End occupancy (mark occupiedUntil = today).
+
+**Auth:** Required
+**Permission:** unit.assign
+
+**Response 200:**
+```json
+{
+  "data": {
+    "message": "occupancy_ended",
+    "occupiedUntil": "datetime"
+  }
+}
+```
+
+---
+
+### GET /societies/:id/units/:nodeId
+Get full details of a flat — owners, occupants, history.
+
+**Auth:** Required
+**Permission:** unit.view_all (admin/builder) OR unit.view_own (if own flat)
+
+**Response 200:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "name": "Flat 4B",
+    "code": "4B",
+    "floor": 4,
+    "bhk": "2BHK",
+    "area": 950,
+    "path": "Tower A → Wing 1",
+    "isVacant": false,
+    "owners": [
+      {
+        "id": "uuid",
+        "name": "Arjun Mehta",
+        "phone": "+919222222222",
+        "ownershipType": "PRIMARY_OWNER",
+        "isPrimary": true,
+        "ownedFrom": "datetime",
+        "ownedUntil": null
+      }
+    ],
+    "currentOccupants": [
+      {
+        "id": "uuid",
+        "name": "Arjun Mehta",
+        "phone": "+919222222222",
+        "occupancyType": "OWNER_RESIDENT",
+        "isPrimary": true,
+        "occupiedFrom": "datetime"
+      }
+    ],
+    "occupancyHistory": [
+      {
+        "name": "Priya Shah",
+        "occupancyType": "TENANT",
+        "occupiedFrom": "datetime",
+        "occupiedUntil": "datetime"
+      }
+    ]
+  }
+}
+```
+
+---
+
+### GET /societies/:id/units
+List all units with occupancy status.
+
+**Auth:** Required
+**Permission:** unit.view_all
+
+**Query params:**
+status → vacant, occupied, all (default: all)
+tower  → filter by tower nodeId
+
+**Response 200:**
+```json
+{
+  "data": {
+    "units": [
+      {
+        "id": "uuid",
+        "name": "Flat 4B",
+        "path": "Tower A → Wing 1",
+        "isVacant": false,
+        "primaryOwner": "Arjun Mehta",
+        "primaryOccupant": "Arjun Mehta",
+        "occupancyType": "OWNER_RESIDENT"
+      },
+      {
+        "id": "uuid",
+        "name": "Flat 5C",
+        "path": "Tower A → Wing 2",
+        "isVacant": true,
+        "primaryOwner": "Vikram Builder",
+        "primaryOccupant": null,
+        "occupancyType": null
+      }
+    ],
+    "total": 48,
+    "occupied": 36,
+    "vacant": 12
+  }
+}
+```
+
+---
+
+### GET /societies/:id/members/:memberId/units
+Get all flats linked to a specific member.
+Used for My Home screen.
+
+**Auth:** Required
+**Permission:** unit.view_all OR unit.view_own (own member only)
+
+**Response 200:**
+```json
+{
+  "data": {
+    "ownerships": [
+      {
+        "flatId": "uuid",
+        "flatName": "Flat 4B",
+        "path": "Tower A → Wing 1",
+        "ownershipType": "PRIMARY_OWNER",
+        "isPrimary": true,
+        "ownedFrom": "datetime",
+        "coOwners": [
+          {
+            "name": "Meera Mehta",
+            "ownershipType": "CO_OWNER"
+          }
+        ]
+      }
+    ],
+    "occupancies": [
+      {
+        "flatId": "uuid",
+        "flatName": "Flat 4B",
+        "path": "Tower A → Wing 1",
+        "occupancyType": "OWNER_RESIDENT",
+        "isPrimary": true,
+        "occupiedFrom": "datetime",
+        "coOccupants": [
+          {
+            "name": "Meera Mehta",
+            "occupancyType": "FAMILY"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Mobile Screens Needed
+Admin side:
+AssignUnitScreen
+→ Triggered from MemberDetailScreen
+→ Pick flat from structure tree
+→ Choose ownership type
+→ Choose occupancy type
+→ Confirm
+UnitDetailScreen
+→ Shows owners, occupants, history
+→ Add/remove owner button
+→ Add/remove occupant button
+→ Access from StructureScreen (tap a unit)
+UnitInventoryScreen
+→ List of all units
+→ Filter: All / Occupied / Vacant
+→ Each row: flat name, status, who lives there
+Resident side:
+MyHomeScreen
+→ Flat name, path, details
+→ Co-owners
+→ Co-occupants
+→ Occupancy history
+→ Access from Dashboard
+
+---
+
+## User Flows
+
+### Flow 1 — Admin assigns flat to resident
+Admin opens Members → finds Arjun (Pending Setup)
+Taps Arjun → Member Detail screen
+Taps "Assign Unit" button
+Structure picker opens → shows all UNIT nodes
+Admin picks Flat 4B
+Chooses ownership type: PRIMARY_OWNER
+Chooses occupancy type: OWNER_RESIDENT
+Confirms
+→ POST /ownership + POST /occupancy
+→ Arjun moves from Pending Setup to Active
+→ Shows Flat 4B · Owner · Resident
+
+### Flow 2 — Admin views vacant flats
+Admin opens Unit Inventory
+Filters by: Vacant
+Sees: Flat 5C, Flat 7B, Flat 9A
+Taps Flat 5C → Unit Detail
+Sees: Owner is Vikram Builder, no occupant
+Taps "Add Occupant" → member picker
+Selects a member → occupancy created
+
+### Flow 3 — Resident views My Home
+Resident opens Dashboard
+Sees "My Home" action
+Taps → My Home screen
+Sees: Flat 4B · Tower A · Wing 1
+2BHK · Floor 4 · 950 sq.ft
+Owner-Resident
+Co-owners: Meera Mehta (Co-owner)
+Co-occupants: Meera Mehta (Family)
+
+### Flow 4 — Admin removes occupant
+Admin opens Unit Detail for Flat 4B
+Sees Priya as current occupant (Tenant)
+Taps end occupancy for Priya
+Confirms
+→ DELETE /occupancy/:id
+→ occupiedUntil = today
+→ Flat 4B becomes vacant
+
+---
+
+## Edge Cases
+Assigning non-UNIT node:
+POST /ownership or /occupancy with a Tower node
+→ 400 not_a_unit
+Assigning member not in society:
+→ 404 member_not_found
+Two PRIMARY_OWNERs on same flat:
+Second assignment with isPrimary: true
+→ 400 already_has_primary
+Admin must end first or use CO_OWNER
+Member already occupying this flat:
+Same member added twice to same flat
+→ 400 already_occupying
+Member with no active occupancy visits My Home:
+→ Empty state: "No unit assigned yet"
+→ "Contact your admin to get assigned"
+Unit with no metadata (no BHK, floor, area):
+Show what exists, skip missing fields
+Never crash on missing metadata
+Gatekeeper tries to view unit details:
+→ 403 insufficient_permissions
+Resident tries to view another member's flat:
+→ 403 insufficient_permissions
+
+---
+
+## Files To Create
+apps/api/src/routes/units.ts
+prisma/migrations/XXXXX_add_unit_assignment/
+docs/briefs/unit-assignment.md  ← this file
+
+## Files To Update
+apps/api/src/app.ts          → register units router
+prisma/schema.prisma         → ownedUntil field + enums
+prisma/seed.ts               → unit permissions + role bundles
+docs/API.md                  → all unit endpoints
+docs/DECISIONS.md            → decisions 025-030
+docs/MOBILE_CONTEXT.md       → new screens + endpoints
+
+---
+
+## Decision Log
+
+### Decision 025 — ownedUntil added now for V2 readiness
+**Date:** April 2026
+**Decision:** Add ownedUntil to unit_ownerships now
+even though ownership transfer UI is V2.
+**Reason:** Adding field later requires migration.
+Adding now costs nothing.
+Enables full ownership history from day one.
+
+### Decision 026 — Ownership and occupancy are separate records
+**Date:** April 2026
+**Decision:** Owner and occupant tracked independently.
+One person can own a flat but not live there.
+Another person can live there without owning it.
+**Reason:** Reflects real Indian society reality.
+Builder-owned rentals, tenant arrangements,
+and investment properties are all common.
+
+### Decision 027 — Deactivate does not end occupancy
+**Date:** April 2026
+**Decision:** Deactivating a member removes app access only.
+Occupancy record untouched.
+Only explicit moveout ends occupancy.
+**Reason:** Deactivation is an app concern.
+Physical occupancy is a real world fact.
+These are independent concepts.
+
+### Decision 028 — Multiple owners and occupants per flat
+**Date:** April 2026
+**Decision:** No hard limit on ownership or occupancy records per flat.
+One marked isPrimary for display purposes.
+**Reason:** Joint ownership and family arrangements
+are standard in Indian residential societies.
+
+### Decision 029 — Builder treated as any other owner
+**Date:** April 2026
+**Decision:** Builder ownership recorded same as any member.
+No special UI treatment for builder-owned flats.
+**Reason:** Keeps architecture consistent.
+Admin can see all flats regardless of who owns them.
+
+### Decision 030 — My Home shows primary flat on dashboard
+**Date:** April 2026
+**Decision:** Dashboard shows primary flat details only.
+Full My Home screen shows all linked flats.
+**Reason:** Dashboard must stay clean.
+Members with multiple flats get full detail in My Home.
+
+---
+
+## Definition of Done
+□ Migration runs cleanly — ownedUntil added
+□ New enums in schema — OwnershipType, OccupancyType
+□ New permissions seeded in all role bundles
+□ POST /units/:nodeId/ownership — assign owner
+□ DELETE /units/:nodeId/ownership/:id — end ownership
+□ POST /units/:nodeId/occupancy — assign occupant
+□ DELETE /units/:nodeId/occupancy/:id — end occupancy
+□ GET /units/:nodeId — flat detail with owners + occupants
+□ GET /units — all flats with vacancy status
+□ GET /members/:memberId/units — member's flats
+□ Assigning non-UNIT node blocked — 400
+□ Double primary owner blocked — 400
+□ Member not in society blocked — 404
+□ Resident can only view own flats — enforced
+□ Vacant flat tracking correct
+□ Pending Setup → Active after assignment
+□ API.md updated
+□ DECISIONS.md updated
+□ MOBILE_CONTEXT.md updated
+□ Tests written — all cases covered
+□ PR merged to dev
+
+---
+
+## Out of Scope
+Ownership transfer UI
+Non-app owner records
+Bulk unit assignment
+Maintenance charge calculation
+Payment tracking
+Unit documents or legal records
+Floor plan upload


### PR DESCRIPTION
### Backend
- 7 new endpoints for unit ownership and occupancy management
- GET /units — list all units with vacancy status
- GET /units/:nodeId — full unit detail with history
- POST/DELETE /units/:nodeId/ownership — assign and end ownership
- POST/DELETE /units/:nodeId/occupancy — assign and end occupancy
- GET /members/:memberId/units — My Home data

### Schema
- ownedUntil added to unit_ownerships
- New enums: PRIMARY_OWNER/CO_OWNER, OWNER_RESIDENT/TENANT/FAMILY/CARETAKER
- New permissions: unit.assign, unit.view_all, unit.view_own

### Fixes
- Builder and Gatekeeper no longer show in pendingSetup
- Only Resident and Co-resident show pendingSetup when no unit assigned

### Tests
- 54 new tests in units.test.ts
- 186 total tests passing
- All 8 test suites green

### Docs
- API.md updated with all unit endpoints
- DECISIONS.md updated with decisions 025-030
- MOBILE_CONTEXT.md updated with new screens
- docs/briefs/unit-assignment.md added
