### PR TITLE
feat: mobile unit screens, villa support, ownership security

### DIFF
--- a/apps/api/src/middleware/rateLimit.ts
+++ b/apps/api/src/middleware/rateLimit.ts
@@ -41,7 +41,7 @@ const createRateLimiter = (
 }
 
 // OTP specific — 3 requests per hour per IP
-export const otpRateLimit = process.env.NODE_ENV === 'test'
+export const otpRateLimit = (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development')
   ? (_req: Request, _res: Response, next: NextFunction) => next()
   : createRateLimiter(3, 60, 'otp_rate_limit_exceeded')
 

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -378,6 +378,7 @@ router.get('/me', authenticate, async (req: AuthRequest, res: Response) => {
         isProfileComplete: !!user.person?.fullName
       },
       memberships: user.memberships.map(m => ({
+        id: m.id,
         org: {
           id: m.org.id,
           name: m.org.name

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -362,6 +362,9 @@ router.get('/me', authenticate, async (req: AuthRequest, res: Response) => {
               }
             }
           }
+        },
+        _count: {
+          select: { memberships: true }
         }
       }
     })
@@ -377,6 +380,7 @@ router.get('/me', authenticate, async (req: AuthRequest, res: Response) => {
         name: user.person?.fullName,
         isProfileComplete: !!user.person?.fullName
       },
+      hasAnyMembership: user._count.memberships > 0,
       memberships: user.memberships.map(m => ({
         id: m.id,
         org: {

--- a/apps/api/src/routes/units.ts
+++ b/apps/api/src/routes/units.ts
@@ -20,9 +20,11 @@ const getPersonId = async (userId: string): Promise<string | null> => {
 // ─────────────────────────────────────────────
 // Helper — verify node is a UNIT type
 // ─────────────────────────────────────────────
+const ASSIGNABLE_TYPES = ['UNIT', 'VILLA', 'FLOOR', 'PLOT'] as const
+
 const verifyUnit = async (nodeId: string, orgId: string) => {
   return prisma.propertyNode.findFirst({
-    where: { id: nodeId, orgId, nodeType: 'UNIT' }
+    where: { id: nodeId, orgId, nodeType: { in: [...ASSIGNABLE_TYPES] } }
   })
 }
 
@@ -58,7 +60,7 @@ router.get(
       const { status, tower } = req.query
 
       // Get all UNIT nodes in this society
-      const whereNode: any = { orgId, nodeType: 'UNIT' }
+      const whereNode: any = { orgId, nodeType: { in: [...ASSIGNABLE_TYPES] } }
       if (tower) {
         // Filter units under a specific tower
         const towerNode = await prisma.propertyNode.findFirst({
@@ -146,7 +148,7 @@ router.get(
       const canViewOwn = permissions.includes('unit.view_own')
 
       const unit = await prisma.propertyNode.findFirst({
-        where: { id: nodeId, orgId, nodeType: 'UNIT' },
+        where: { id: nodeId, orgId, nodeType: { in: [...ASSIGNABLE_TYPES] } },
         include: {
           ownerships: {
             include: { person: true },

--- a/apps/api/src/routes/units.ts
+++ b/apps/api/src/routes/units.ts
@@ -277,6 +277,30 @@ router.post(
         }
       }
 
+      // Check for duplicate ownership (same person already owns this unit)
+      const existingOwners = await prisma.unitOwnership.findMany({
+        where: { unitId: nodeId, ownedUntil: null }
+      })
+
+      const alreadyOwner = existingOwners.some(o => o.personId === person.id)
+      if (alreadyOwner) {
+        return sendError(res, 'already_owner', 400, {
+          message: 'This member already has an active ownership record for this unit.'
+        })
+      }
+
+      // Prevent self-assigning to a flat that already has a different owner
+      if (userId === req.user!.userId && existingOwners.length > 0) {
+        const isOnlyThisPerson = existingOwners.every(
+          o => o.personId === person.id
+        )
+        if (!isOnlyThisPerson) {
+          return sendError(res, 'cannot_self_assign_occupied', 400, {
+            message: 'This unit already has an owner. You cannot assign yourself to it.'
+          })
+        }
+      }
+
       // Create ownership record
       const ownership = await prisma.unitOwnership.create({
         data: {

--- a/apps/api/tests/units.test.ts
+++ b/apps/api/tests/units.test.ts
@@ -292,7 +292,7 @@ describe('GET /societies/:id/units/:nodeId', () => {
       .post(`/api/societies/${orgId}/units/${flat4BId}/ownership`)
       .set('Authorization', `Bearer ${builderToken}`)
       .send({
-        userId: builderUserId,
+        userId: gatekeeperUserId,
         ownershipType: 'CO_OWNER',
         isPrimary: false
       })
@@ -300,7 +300,7 @@ describe('GET /societies/:id/units/:nodeId', () => {
     expect(res.status).toBe(201)
     expect(res.body.data.ownershipType).toBe('CO_OWNER')
     expect(res.body.data.isPrimary).toBe(false)
-    expect(res.body.data.member.name).toBe('Vikram Builder')
+    expect(res.body.data.member.name).toBe('Ramesh Gate')
 
     createdOwnershipId = res.body.data.id
   })
@@ -310,7 +310,7 @@ describe('GET /societies/:id/units/:nodeId', () => {
       .post(`/api/societies/${orgId}/units/${flat4BId}/ownership`)
       .set('Authorization', `Bearer ${builderToken}`)
       .send({
-        userId: builderUserId,
+        userId: gatekeeperUserId,
         ownershipType: 'PRIMARY_OWNER',
         isPrimary: true
       })
@@ -392,6 +392,34 @@ describe('GET /societies/:id/units/:nodeId', () => {
       })
 
     expect(res.status).toBe(401)
+  })
+
+  it('cannot assign same member twice — 400 already_owner', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${orgId}/units/${flat4BId}/ownership`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({
+          userId: arjunUserId,
+          ownershipType: 'CO_OWNER',
+          isPrimary: false
+        })
+
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('already_owner')
+    })
+
+  it('cannot self-assign to flat with existing different owner — 400', async () => {
+    const res = await request(app)
+      .post(`/api/societies/${orgId}/units/${flat4BId}/ownership`)
+      .set('Authorization', `Bearer ${builderToken}`)
+      .send({
+        userId: builderUserId,
+        ownershipType: 'CO_OWNER',
+        isPrimary: false
+      })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error).toBe('cannot_self_assign_occupied')
   })
 })
 
@@ -634,7 +662,7 @@ describe('DELETE /societies/:id/units/:nodeId/ownership/:ownershipId', () => {
     const res = await request(app)
       .post(`/api/societies/${orgId}/units/${flat4BId}/ownership`)
       .set('Authorization', `Bearer ${builderToken}`)
-      .send({ userId: builderUserId, ownershipType: 'CO_OWNER', isPrimary: false })
+      .send({ userId: gatekeeperUserId, ownershipType: 'CO_OWNER', isPrimary: false })
     ownershipToDeleteId = res.body.data.id
   })
 
@@ -789,7 +817,7 @@ describe('History and vacancy tracking', () => {
     const assign = await request(app)
       .post(`/api/societies/${orgId}/units/${flat4BId}/ownership`)
       .set('Authorization', `Bearer ${builderToken}`)
-      .send({ userId: builderUserId, ownershipType: 'CO_OWNER', isPrimary: false })
+      .send({ userId: gatekeeperUserId, ownershipType: 'CO_OWNER', isPrimary: false })
 
     await request(app)
       .delete(`/api/societies/${orgId}/units/${flat4BId}/ownership/${assign.body.data.id}`)

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -22,6 +22,7 @@ interface AuthState {
   memberships: Membership[]
   permissions: string[]
   currentOrgId: string | null
+  hasAnyMembership: boolean
   isLoading: boolean
   isAuthenticated: boolean
 }
@@ -40,6 +41,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     memberships: [],
     permissions: [],
     currentOrgId: null,
+    hasAnyMembership: false,
     isLoading: true,
     isAuthenticated: false,
   })
@@ -77,6 +79,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         memberships: data.memberships,
         permissions,
         currentOrgId,
+        hasAnyMembership: data.hasAnyMembership ?? false,
         isLoading: false,
         isAuthenticated: true,
       })
@@ -99,6 +102,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       memberships: [],
       permissions: [],
       currentOrgId: null,
+      hasAnyMembership: false,
       isLoading: false,
       isAuthenticated: false,
     })

--- a/apps/mobile/src/context/AuthContext.tsx
+++ b/apps/mobile/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ interface User {
 }
 
 interface Membership {
+  id: string
   org: { id: string; name: string }
   role: string
   permissions: string[]

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -11,6 +11,10 @@ import { SwitchSocietyScreen } from '../screens/society/SwitchSocietyScreen'
 import { ComplaintListScreen } from '../screens/complaints/ComplaintListScreen'
 import { RaiseComplaintScreen } from '../screens/complaints/RaiseComplaintScreen'
 import { ComplaintDetailScreen } from '../screens/complaints/ComplaintDetailScreen'
+import { UnitInventoryScreen } from '../screens/units/UnitInventoryScreen'
+import { UnitDetailScreen } from '../screens/units/UnitDetailScreen'
+import { AssignUnitScreen } from '../screens/units/AssignUnitScreen'
+import { MyHomeScreen } from '../screens/units/MyHomeScreen'
 import { Colors } from '../constants/colors'
 
 export type AppStackParamList = {
@@ -25,6 +29,16 @@ export type AppStackParamList = {
   ComplaintList: { societyId: string }
   RaiseComplaint: { societyId: string }
   ComplaintDetail: { societyId: string; complaintId: string; title: string }
+  UnitInventory: { societyId: string }
+  UnitDetail: { societyId: string; unitId: string; unitName: string }
+  AssignUnit: {
+    societyId: string
+    memberId: string
+    memberName: string
+    prefillUnitId?: string
+    prefillUnitName?: string
+  }
+  MyHome: { societyId: string; memberId: string }
 }
 
 const Stack = createNativeStackNavigator<AppStackParamList>()
@@ -61,6 +75,10 @@ export function AppNavigator({ initialSocietyId }: AppNavigatorProps) {
       <Stack.Screen name="ComplaintList" component={ComplaintListScreen} options={{ title: 'Complaints' }} />
       <Stack.Screen name="RaiseComplaint" component={RaiseComplaintScreen} options={{ title: 'Raise Complaint' }} />
       <Stack.Screen name="ComplaintDetail" component={ComplaintDetailScreen} options={({ route }) => ({ title: route.params.title })} />
+      <Stack.Screen name="UnitInventory" component={UnitInventoryScreen} options={{ title: 'Units' }} />
+      <Stack.Screen name="UnitDetail" component={UnitDetailScreen} options={({ route }) => ({ title: route.params.unitName })} />
+      <Stack.Screen name="AssignUnit" component={AssignUnitScreen} options={{ title: 'Assign Unit' }} />
+      <Stack.Screen name="MyHome" component={MyHomeScreen} options={{ title: 'My Home' }} />
     </Stack.Navigator>
   )
 }

--- a/apps/mobile/src/navigation/RootNavigator.tsx
+++ b/apps/mobile/src/navigation/RootNavigator.tsx
@@ -1,15 +1,36 @@
 import React from 'react'
+import { View, Text, StyleSheet } from 'react-native'
 import { NavigationContainer } from '@react-navigation/native'
 import { AuthNavigator } from './AuthNavigator'
 import { AppNavigator } from './AppNavigator'
 import { LoadingSpinner } from '../components/LoadingSpinner'
+import { Button } from '../components/Button'
 import { useAuth } from '../hooks/useAuth'
+import { Colors } from '../constants/colors'
+import { Spacing } from '../constants/spacing'
 
 export function RootNavigator() {
-  const { isLoading, isAuthenticated, currentOrgId } = useAuth()
+  const { isLoading, isAuthenticated, currentOrgId, memberships, hasAnyMembership, signOut } = useAuth()
 
   if (isLoading) {
     return <LoadingSpinner fullScreen />
+  }
+
+  // Authenticated but no active memberships, and has been in a society before
+  // → deactivated / moved-out member, not a brand-new user
+  if (isAuthenticated && memberships.length === 0 && hasAnyMembership) {
+    return (
+      <View style={styles.container}>
+        <View style={styles.content}>
+          <Text style={styles.title}>Access Removed</Text>
+          <Text style={styles.message}>
+            Your access to this society has been removed.{'\n'}
+            Please contact your admin to restore access.
+          </Text>
+          <Button label="Sign out" onPress={signOut} style={styles.button} />
+        </View>
+      </View>
+    )
   }
 
   return (
@@ -21,3 +42,33 @@ export function RootNavigator() {
     </NavigationContainer>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: Spacing.screenPadding * 2,
+    gap: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: Colors.text,
+    textAlign: 'center',
+  },
+  message: {
+    fontSize: 15,
+    color: Colors.subtle,
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: 8,
+  },
+  button: {
+    alignSelf: 'stretch',
+  },
+})

--- a/apps/mobile/src/screens/members/MemberDetailScreen.tsx
+++ b/apps/mobile/src/screens/members/MemberDetailScreen.tsx
@@ -102,6 +102,7 @@ export function MemberDetailScreen({ route, navigation }: Props) {
 
   const canRemove = permissions.includes('member.remove')
   const canReactivate = permissions.includes('member.reactivate')
+  const canAssignUnit = permissions.includes('unit.assign')
 
   const [member, setMember] = useState<MemberDetail | null>(null)
   const [loading, setLoading] = useState(true)
@@ -297,10 +298,24 @@ export function MemberDetailScreen({ route, navigation }: Props) {
         ) : null}
 
         {/* ── Actions ── */}
-        {(canRemove || canReactivate) ? (
+        {(canRemove || canReactivate || canAssignUnit) ? (
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Actions</Text>
             <View style={styles.actionButtons}>
+              {/* Assign Unit — admin/builder only */}
+              {canAssignUnit ? (
+                <Button
+                  label="Assign Unit"
+                  variant="primary"
+                  onPress={() =>
+                    navigation.navigate('AssignUnit', {
+                      societyId,
+                      memberId: member.userId,
+                      memberName: member.name,
+                    })
+                  }
+                />
+              ) : null}
               {/* Deactivate — active member only */}
               {canRemove && isActive ? (
                 <Button

--- a/apps/mobile/src/screens/members/MemberListScreen.tsx
+++ b/apps/mobile/src/screens/members/MemberListScreen.tsx
@@ -242,9 +242,13 @@ function MemberRow({ member, onPress, pending = false }: MemberRowProps) {
   const avatarColor = getAvatarColor(member.name)
   const initial = member.name.trim().charAt(0).toUpperCase()
 
-  const unitLine = member.unit
-    ? `${member.unit}${member.occupancyType ? ' · ' + (OCCUPANCY_LABEL[member.occupancyType] ?? member.occupancyType) : ''}`
-    : 'No unit assigned'
+  const isResidentRole = member.role === 'Resident' || member.role === 'Co-resident'
+
+  const unitLine = isResidentRole
+    ? (member.unit
+        ? `${member.unit}${member.occupancyType ? ' · ' + (OCCUPANCY_LABEL[member.occupancyType] ?? member.occupancyType) : ''}`
+        : 'No unit assigned')
+    : null
 
   return (
     <Pressable
@@ -264,9 +268,11 @@ function MemberRow({ member, onPress, pending = false }: MemberRowProps) {
             <Text style={[rowStyles.badgeText, { color: badge.text }]}>{member.role}</Text>
           </View>
         </View>
-        <Text style={[rowStyles.unit, pending && rowStyles.unitPending]} numberOfLines={1}>
-          {pending ? '⏳ ' : ''}{unitLine}
-        </Text>
+        {unitLine !== null ? (
+          <Text style={[rowStyles.unit, pending && rowStyles.unitPending]} numberOfLines={1}>
+            {pending ? '⏳ ' : ''}{unitLine}
+          </Text>
+        ) : null}
       </View>
 
       {/* Chevron */}

--- a/apps/mobile/src/screens/society/CreateSocietyScreen.tsx
+++ b/apps/mobile/src/screens/society/CreateSocietyScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { View, Text, Pressable, StyleSheet, ScrollView } from 'react-native'
+import { View, Text, Pressable, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { ScreenWrapper } from '../../components/ScreenWrapper'
 import { TextInput } from '../../components/TextInput'
@@ -51,7 +51,7 @@ interface FormErrors {
 
 export function CreateSocietyScreen({ route, navigation }: Props) {
   const source = route.params?.source
-  const { loadUser } = useAuth()
+  const { loadUser, signOut } = useAuth()
   const [form, setForm] = useState<FormState>({
     name: '',
     address: '',
@@ -220,6 +220,10 @@ export function CreateSocietyScreen({ route, navigation }: Props) {
         style={styles.submitBtn}
       />
 
+      <TouchableOpacity onPress={signOut} hitSlop={12} style={styles.signOutRow}>
+        <Text style={styles.signOutText}>Sign out</Text>
+      </TouchableOpacity>
+
       <BottomSheetPicker
         visible={pickerOpen}
         title="Society Type"
@@ -313,5 +317,14 @@ const styles = StyleSheet.create({
   submitBtn: {
     marginTop: Spacing.sectionGap,
     marginBottom: 8,
+  },
+  signOutRow: {
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  signOutText: {
+    fontSize: 14,
+    color: Colors.subtle,
+    fontWeight: '500',
   },
 })

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -13,11 +13,10 @@ import {
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { ScreenWrapper } from '../../components/ScreenWrapper'
 import { Card } from '../../components/Card'
+import { Button } from '../../components/Button'
 import { LoadingSpinner } from '../../components/LoadingSpinner'
-import { EmptyState } from '../../components/EmptyState'
 import { Toast } from '../../components/Toast'
 import { TextInput } from '../../components/TextInput'
-import { Button } from '../../components/Button'
 import { AppStackParamList } from '../../navigation/AppNavigator'
 import { useAuth } from '../../hooks/useAuth'
 import { useSociety } from '../../hooks/useSociety'
@@ -149,12 +148,14 @@ export function DashboardScreen({ route, navigation }: Props) {
 
   if (error || !society) {
     return (
-      <EmptyState
-        title="Could not load society"
-        subtitle={error ?? 'Something went wrong. Please try again.'}
-        actionLabel="Retry"
-        onAction={load}
-      />
+      <ScreenWrapper>
+        <View style={styles.errorState}>
+          <Text style={styles.errorTitle}>Could not load society</Text>
+          <Text style={styles.errorSubtitle}>{error ?? 'Something went wrong. Please try again.'}</Text>
+          <Button label="Retry" onPress={load} style={styles.errorBtn} />
+          <Button label="Sign out" variant="secondary" onPress={signOut} style={styles.errorBtn} />
+        </View>
+      </ScreenWrapper>
     )
   }
 
@@ -370,6 +371,32 @@ function ActionRow({ icon, label, subtitle, onPress }: ActionRowProps) {
 const styles = StyleSheet.create({
   wrapper: {
     backgroundColor: Colors.background,
+  },
+
+  // Error state
+  errorState: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 12,
+  },
+  errorTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: Colors.text,
+    textAlign: 'center',
+  },
+  errorSubtitle: {
+    fontSize: 14,
+    color: Colors.subtle,
+    textAlign: 'center',
+    lineHeight: 21,
+    marginBottom: 4,
+  },
+  errorBtn: {
+    paddingHorizontal: 32,
+    alignSelf: 'stretch',
   },
   content: {
     padding: Spacing.screenPadding,

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -132,8 +132,16 @@ export function DashboardScreen({ route, navigation }: Props) {
     permissions.includes('complaint.create') ||
     permissions.includes('complaint.view_own') ||
     permissions.includes('complaint.view_all')
+  const canViewUnitInventory = permissions.includes('unit.view_all')
+  const canViewMyHome = permissions.includes('unit.view_own')
 
-  const hasAnyAction = canViewStructure || canInvite || canViewMembers || canSwitchSociety || canViewComplaints
+  // memberId for MyHome — find current user's membership in this society
+  const currentMembership = memberships.find((m) => m.org.id === societyId)
+  const currentMemberId = currentMembership?.id ?? null
+
+  const hasAnyAction =
+    canViewStructure || canInvite || canViewMembers || canSwitchSociety ||
+    canViewComplaints || canViewUnitInventory || canViewMyHome
 
   if (isLoading) {
     return <LoadingSpinner fullScreen />
@@ -236,6 +244,22 @@ export function DashboardScreen({ route, navigation }: Props) {
                   label="Complaints"
                   subtitle="View and raise complaints"
                   onPress={() => navigation.navigate('ComplaintList', { societyId })}
+                />
+              ) : null}
+              {canViewUnitInventory ? (
+                <ActionRow
+                  icon="🏢"
+                  label="Unit Inventory"
+                  subtitle="All flats, owners, and occupants"
+                  onPress={() => navigation.navigate('UnitInventory', { societyId })}
+                />
+              ) : null}
+              {canViewMyHome && currentMemberId ? (
+                <ActionRow
+                  icon="🏠"
+                  label="My Home"
+                  subtitle="Your flat details and co-occupants"
+                  onPress={() => navigation.navigate('MyHome', { societyId, memberId: currentMemberId })}
                 />
               ) : null}
               {canSwitchSociety ? (

--- a/apps/mobile/src/screens/units/AssignUnitScreen.tsx
+++ b/apps/mobile/src/screens/units/AssignUnitScreen.tsx
@@ -1,0 +1,602 @@
+import React, { useState, useCallback, useEffect, useRef } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TextInput,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  TouchableWithoutFeedback,
+  Modal,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { Button } from '../../components/Button'
+import { Toast } from '../../components/Toast'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
+import {
+  listUnits,
+  assignOwnership,
+  assignOccupancy,
+  UnitListItem,
+  OwnershipType,
+  OccupancyType,
+} from '../../services/units'
+import { getApiErrorCode } from '../../services/api'
+import { getErrorMessage } from '../../utils/errorMessages'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'AssignUnit'>
+
+// ─── Picker options ───────────────────────────────────────────────────────────
+
+type OwnershipOption = OwnershipType | 'NONE'
+type OccupancyOption = OccupancyType | 'NONE'
+
+const OWNERSHIP_OPTIONS: { label: string; value: OwnershipOption }[] = [
+  { label: 'None (occupant only)', value: 'NONE' },
+  { label: 'Primary Owner', value: 'PRIMARY_OWNER' },
+  { label: 'Co-owner', value: 'CO_OWNER' },
+]
+
+const OCCUPANCY_OPTIONS: { label: string; value: OccupancyOption }[] = [
+  { label: 'None (owner only)', value: 'NONE' },
+  { label: 'Owner Resident', value: 'OWNER_RESIDENT' },
+  { label: 'Tenant', value: 'TENANT' },
+  { label: 'Family', value: 'FAMILY' },
+  { label: 'Caretaker', value: 'CARETAKER' },
+]
+
+const OWNERSHIP_COLORS: Record<string, { bg: string; text: string }> = {
+  PRIMARY_OWNER: { bg: '#ede9fe', text: Colors.primary },
+  CO_OWNER: { bg: '#e0e7ff', text: '#6366f1' },
+  NONE: { bg: Colors.border, text: Colors.subtle },
+}
+
+const OCCUPANCY_COLORS: Record<string, { bg: string; text: string }> = {
+  OWNER_RESIDENT: { bg: '#dcfce7', text: Colors.success },
+  TENANT: { bg: '#fef3c7', text: '#d97706' },
+  FAMILY: { bg: '#e0f2fe', text: '#0284c7' },
+  CARETAKER: { bg: '#fce7f3', text: '#be185d' },
+  NONE: { bg: Colors.border, text: Colors.subtle },
+}
+
+export function AssignUnitScreen({ route, navigation }: Props) {
+  const { societyId, memberId, memberName, prefillUnitId, prefillUnitName } = route.params
+  const { permissions } = useAuth()
+
+  const canAssign = permissions.includes('unit.assign')
+
+  // Step 1 state
+  const [allUnits, setAllUnits] = useState<UnitListItem[]>([])
+  const [loadingUnits, setLoadingUnits] = useState(true)
+  const [searchText, setSearchText] = useState('')
+
+  // Step 2 state — selected flat + type choices
+  const [selectedUnit, setSelectedUnit] = useState<UnitListItem | null>(null)
+  const [ownershipType, setOwnershipType] = useState<OwnershipOption>('NONE')
+  const [occupancyType, setOccupancyType] = useState<OccupancyOption>('NONE')
+  const [isPrimaryOwner, setIsPrimaryOwner] = useState(false)
+  const [isPrimaryOccupant, setIsPrimaryOccupant] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Picker sheet state
+  const [activePicker, setActivePicker] = useState<'ownership' | 'occupancy' | null>(null)
+
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => { isMounted.current = false }
+  }, [])
+
+  // Load all units for step 1
+  const loadUnits = useCallback(async () => {
+    try {
+      const result = await listUnits(societyId)
+      if (!isMounted.current) return
+      setAllUnits(result.units)
+    } catch {
+      if (isMounted.current) {
+        setToast({ message: 'Could not load units.', type: 'error' })
+      }
+    } finally {
+      if (isMounted.current) setLoadingUnits(false)
+    }
+  }, [societyId])
+
+  useEffect(() => {
+    loadUnits()
+  }, [loadUnits])
+
+  // If prefill provided (coming from UnitDetailScreen), skip step 1
+  useEffect(() => {
+    if (prefillUnitId && prefillUnitName) {
+      setSelectedUnit({
+        id: prefillUnitId,
+        name: prefillUnitName,
+        code: null,
+        path: null,
+        metadata: null,
+        isVacant: true,
+        primaryOwner: null,
+        primaryOccupant: null,
+        occupancyType: null,
+      })
+    }
+  }, [prefillUnitId, prefillUnitName])
+
+  // Validate title when memberId supplied (from MemberDetail) or required prefill
+  const effectiveMemberId = memberId
+  const effectiveMemberName = memberName || 'Member'
+
+  useEffect(() => {
+    navigation.setOptions({
+      title: `Assign Unit — ${effectiveMemberName}`,
+    })
+  }, [navigation, effectiveMemberName])
+
+  const filteredUnits = allUnits.filter((u) =>
+    u.name.toLowerCase().includes(searchText.toLowerCase()),
+  )
+
+  // ── Step 2: submit ────────────────────────────────────────────────────────
+
+  async function handleConfirm() {
+    if (!selectedUnit) return
+    if (ownershipType === 'NONE' && occupancyType === 'NONE') {
+      setToast({ message: 'Select at least one ownership or occupancy type.', type: 'error' })
+      return
+    }
+    if (!effectiveMemberId) {
+      setToast({ message: 'Member not specified.', type: 'error' })
+      return
+    }
+
+    setSubmitting(true)
+    let ownershipError: string | null = null
+    let occupancyError: string | null = null
+
+    try {
+      if (ownershipType !== 'NONE') {
+        try {
+          await assignOwnership(societyId, selectedUnit.id, {
+            userId: effectiveMemberId,
+            ownershipType: ownershipType as OwnershipType,
+            isPrimary: isPrimaryOwner,
+          })
+        } catch (e) {
+          ownershipError = getErrorMessage(getApiErrorCode(e))
+        }
+      }
+
+      if (occupancyType !== 'NONE') {
+        try {
+          await assignOccupancy(societyId, selectedUnit.id, {
+            userId: effectiveMemberId,
+            occupancyType: occupancyType as OccupancyType,
+            isPrimary: isPrimaryOccupant,
+          })
+        } catch (e) {
+          occupancyError = getErrorMessage(getApiErrorCode(e))
+        }
+      }
+
+      if (ownershipError || occupancyError) {
+        const msgs = [ownershipError, occupancyError].filter(Boolean)
+        setToast({ message: msgs.join(' '), type: 'error' })
+      } else {
+        setToast({ message: `Unit assigned to ${effectiveMemberName}.`, type: 'success' })
+        setTimeout(() => {
+          if (isMounted.current) navigation.goBack()
+        }, 1200)
+      }
+    } finally {
+      if (isMounted.current) setSubmitting(false)
+    }
+  }
+
+  if (!canAssign) {
+    return (
+      <ScreenWrapper>
+        <View style={styles.emptyFull}>
+          <Text style={styles.emptyTitle}>Access restricted</Text>
+          <Text style={styles.emptySub}>You don't have permission to assign units.</Text>
+        </View>
+      </ScreenWrapper>
+    )
+  }
+
+  // ── Step 1: pick a flat ───────────────────────────────────────────────────
+
+  if (!selectedUnit) {
+    return (
+      <ScreenWrapper scroll={false} style={styles.wrapper}>
+        {/* Search bar */}
+        <View style={styles.searchBar}>
+          <TextInput
+            style={styles.searchInput}
+            placeholder="Search flat name..."
+            placeholderTextColor={Colors.subtle}
+            value={searchText}
+            onChangeText={setSearchText}
+            autoCorrect={false}
+            clearButtonMode="while-editing"
+          />
+        </View>
+
+        {loadingUnits ? (
+          <View style={styles.loadingCenter}>
+            <ActivityIndicator color={Colors.primary} />
+          </View>
+        ) : (
+          <FlatList
+            data={filteredUnits}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+              <Pressable
+                onPress={() => setSelectedUnit(item)}
+                style={({ pressed }) => [styles.unitRow, pressed && styles.unitRowPressed]}
+              >
+                <View style={styles.unitRowContent}>
+                  <Text style={styles.unitName}>{item.name}</Text>
+                  {item.path ? (
+                    <Text style={styles.unitPath} numberOfLines={1}>{item.path}</Text>
+                  ) : null}
+                  {item.primaryOccupant ? (
+                    <Text style={styles.unitOccupant}>Occupant: {item.primaryOccupant}</Text>
+                  ) : (
+                    <Text style={styles.unitVacant}>Vacant</Text>
+                  )}
+                </View>
+                <Text style={styles.chevron}>›</Text>
+              </Pressable>
+            )}
+            ListEmptyComponent={
+              <View style={styles.emptyFull}>
+                <Text style={styles.emptyTitle}>No units found</Text>
+                <Text style={styles.emptySub}>Try a different search.</Text>
+              </View>
+            }
+            contentContainerStyle={filteredUnits.length === 0 ? styles.emptyContainer : undefined}
+          />
+        )}
+
+        {toast ? (
+          <Toast message={toast.message} type={toast.type} visible={!!toast} onHide={() => setToast(null)} />
+        ) : null}
+      </ScreenWrapper>
+    )
+  }
+
+  // ── Step 2: choose types ──────────────────────────────────────────────────
+
+  const ownershipColorSet = OWNERSHIP_COLORS[ownershipType] ?? OWNERSHIP_COLORS.NONE
+  const occupancyColorSet = OCCUPANCY_COLORS[occupancyType] ?? OCCUPANCY_COLORS.NONE
+  const ownershipLabel = OWNERSHIP_OPTIONS.find((o) => o.value === ownershipType)?.label ?? ownershipType
+  const occupancyLabel = OCCUPANCY_OPTIONS.find((o) => o.value === occupancyType)?.label ?? occupancyType
+
+  const hasExistingPrimaryOwner = !!selectedUnit.primaryOwner
+  const hasExistingPrimaryOccupant = !!selectedUnit.primaryOccupant
+
+  return (
+    <ScreenWrapper scroll={false} style={styles.wrapper}>
+      <ScrollView contentContainerStyle={styles.step2Content} showsVerticalScrollIndicator={false}>
+        {/* Selected flat */}
+        <View style={styles.selectedFlatCard}>
+          <Text style={styles.selectedFlatLabel}>Selected flat</Text>
+          <Text style={styles.selectedFlatName}>{selectedUnit.name}</Text>
+          {selectedUnit.path ? (
+            <Text style={styles.selectedFlatPath}>{selectedUnit.path}</Text>
+          ) : null}
+          {!prefillUnitId ? (
+            <Pressable onPress={() => setSelectedUnit(null)} hitSlop={8}>
+              <Text style={styles.changeFlat}>Change flat</Text>
+            </Pressable>
+          ) : null}
+        </View>
+
+        {/* Member info */}
+        {effectiveMemberName ? (
+          <View style={styles.memberRow}>
+            <Text style={styles.memberLabel}>Assigning to</Text>
+            <Text style={styles.memberName}>{effectiveMemberName}</Text>
+          </View>
+        ) : null}
+
+        {/* Ownership type picker */}
+        <View style={styles.pickerSection}>
+          <Text style={styles.pickerLabel}>Ownership type</Text>
+          <Pressable
+            onPress={() => setActivePicker('ownership')}
+            style={styles.pickerButton}
+          >
+            <View style={[styles.pickerBadge, { backgroundColor: ownershipColorSet.bg }]}>
+              <Text style={[styles.pickerBadgeText, { color: ownershipColorSet.text }]}>
+                {ownershipLabel}
+              </Text>
+            </View>
+            <Text style={styles.pickerChevron}>›</Text>
+          </Pressable>
+
+          {ownershipType !== 'NONE' && !hasExistingPrimaryOwner ? (
+            <View style={styles.toggleRow}>
+              <Text style={styles.toggleLabel}>Set as primary owner</Text>
+              <Switch
+                value={isPrimaryOwner}
+                onValueChange={setIsPrimaryOwner}
+                trackColor={{ false: Colors.border, true: Colors.primary }}
+                thumbColor={Colors.surface}
+              />
+            </View>
+          ) : null}
+        </View>
+
+        {/* Occupancy type picker */}
+        <View style={styles.pickerSection}>
+          <Text style={styles.pickerLabel}>Occupancy type</Text>
+          <Pressable
+            onPress={() => setActivePicker('occupancy')}
+            style={styles.pickerButton}
+          >
+            <View style={[styles.pickerBadge, { backgroundColor: occupancyColorSet.bg }]}>
+              <Text style={[styles.pickerBadgeText, { color: occupancyColorSet.text }]}>
+                {occupancyLabel}
+              </Text>
+            </View>
+            <Text style={styles.pickerChevron}>›</Text>
+          </Pressable>
+
+          {occupancyType !== 'NONE' && !hasExistingPrimaryOccupant ? (
+            <View style={styles.toggleRow}>
+              <Text style={styles.toggleLabel}>Set as primary occupant</Text>
+              <Switch
+                value={isPrimaryOccupant}
+                onValueChange={setIsPrimaryOccupant}
+                trackColor={{ false: Colors.border, true: Colors.primary }}
+                thumbColor={Colors.surface}
+              />
+            </View>
+          ) : null}
+        </View>
+
+        {/* Confirm */}
+        <Button
+          label="Confirm Assignment"
+          onPress={handleConfirm}
+          loading={submitting}
+          style={styles.confirmBtn}
+        />
+      </ScrollView>
+
+      {/* Picker bottom sheet */}
+      {activePicker ? (
+        <Modal visible animationType="slide" transparent onRequestClose={() => setActivePicker(null)}>
+          <TouchableWithoutFeedback onPress={() => setActivePicker(null)}>
+            <View style={pickerStyles.overlay} />
+          </TouchableWithoutFeedback>
+          <View style={pickerStyles.sheet}>
+            <View style={pickerStyles.handle} />
+            <Text style={pickerStyles.title}>
+              {activePicker === 'ownership' ? 'Ownership type' : 'Occupancy type'}
+            </Text>
+            {(activePicker === 'ownership' ? OWNERSHIP_OPTIONS : OCCUPANCY_OPTIONS).map((opt) => {
+              const isSelected =
+                activePicker === 'ownership' ? ownershipType === opt.value : occupancyType === opt.value
+              return (
+                <TouchableOpacity
+                  key={opt.value}
+                  onPress={() => {
+                    if (activePicker === 'ownership') {
+                      setOwnershipType(opt.value as OwnershipOption)
+                      if (opt.value === 'NONE') setIsPrimaryOwner(false)
+                    } else {
+                      setOccupancyType(opt.value as OccupancyOption)
+                      if (opt.value === 'NONE') setIsPrimaryOccupant(false)
+                    }
+                    setActivePicker(null)
+                  }}
+                  style={[pickerStyles.option, isSelected && pickerStyles.optionSelected]}
+                >
+                  <Text style={[pickerStyles.optionText, isSelected && pickerStyles.optionTextSelected]}>
+                    {opt.label}
+                  </Text>
+                  {isSelected ? <Text style={pickerStyles.checkmark}>✓</Text> : null}
+                </TouchableOpacity>
+              )
+            })}
+          </View>
+        </Modal>
+      ) : null}
+
+      {toast ? (
+        <Toast message={toast.message} type={toast.type} visible={!!toast} onHide={() => setToast(null)} />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  wrapper: { backgroundColor: Colors.background },
+
+  // Step 1
+  searchBar: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 10,
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  searchInput: {
+    backgroundColor: Colors.background,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 15,
+    color: Colors.text,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  loadingCenter: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  unitRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 14,
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    gap: 12,
+    minHeight: Spacing.minTapTarget,
+  },
+  unitRowPressed: { backgroundColor: Colors.background },
+  unitRowContent: { flex: 1, gap: 3 },
+  unitName: { fontSize: 15, fontWeight: '600', color: Colors.text },
+  unitPath: { fontSize: 12, color: Colors.subtle },
+  unitOccupant: { fontSize: 12, color: Colors.subtle },
+  unitVacant: { fontSize: 12, color: '#d97706', fontWeight: '500' },
+  chevron: { fontSize: 22, color: Colors.subtle, lineHeight: 26 },
+  emptyContainer: { flexGrow: 1 },
+  emptyFull: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 8,
+  },
+  emptyTitle: { fontSize: 17, fontWeight: '600', color: Colors.text },
+  emptySub: { fontSize: 14, color: Colors.subtle, textAlign: 'center' },
+
+  // Step 2
+  step2Content: {
+    padding: Spacing.screenPadding,
+    gap: Spacing.sectionGap,
+    paddingBottom: 40,
+  },
+  selectedFlatCard: {
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    padding: 16,
+    gap: 4,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  selectedFlatLabel: { fontSize: 11, fontWeight: '700', color: Colors.subtle, textTransform: 'uppercase', letterSpacing: 0.6 },
+  selectedFlatName: { fontSize: 18, fontWeight: '700', color: Colors.text },
+  selectedFlatPath: { fontSize: 13, color: Colors.subtle },
+  changeFlat: { fontSize: 13, color: Colors.primary, fontWeight: '600', marginTop: 4 },
+
+  memberRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    padding: 16,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  memberLabel: { fontSize: 13, color: Colors.subtle },
+  memberName: { fontSize: 15, fontWeight: '600', color: Colors.text },
+
+  pickerSection: {
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    overflow: 'hidden',
+  },
+  pickerLabel: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.subtle,
+    paddingHorizontal: 16,
+    paddingTop: 14,
+    paddingBottom: 6,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  pickerButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingBottom: 14,
+    gap: 10,
+  },
+  pickerBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    flex: 1,
+  },
+  pickerBadgeText: { fontSize: 14, fontWeight: '600' },
+  pickerChevron: { fontSize: 22, color: Colors.subtle, lineHeight: 26 },
+
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+  },
+  toggleLabel: { fontSize: 14, color: Colors.text, fontWeight: '500' },
+
+  confirmBtn: { marginTop: 8 },
+})
+
+const pickerStyles = StyleSheet.create({
+  overlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.4)' },
+  sheet: {
+    backgroundColor: Colors.surface,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    paddingBottom: 36,
+  },
+  handle: {
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: Colors.border,
+    alignSelf: 'center',
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: Colors.text,
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+  },
+  option: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    minHeight: Spacing.minTapTarget,
+  },
+  optionSelected: { backgroundColor: '#ede9fe' },
+  optionText: { fontSize: 15, color: Colors.text },
+  optionTextSelected: { color: Colors.primary, fontWeight: '600' },
+  checkmark: { fontSize: 16, color: Colors.primary, fontWeight: '700' },
+})

--- a/apps/mobile/src/screens/units/AssignUnitScreen.tsx
+++ b/apps/mobile/src/screens/units/AssignUnitScreen.tsx
@@ -223,7 +223,7 @@ export function AssignUnitScreen({ route, navigation }: Props) {
         <View style={styles.searchBar}>
           <TextInput
             style={styles.searchInput}
-            placeholder="Search flat name..."
+            placeholder="Search unit name..."
             placeholderTextColor={Colors.subtle}
             value={searchText}
             onChangeText={setSearchText}

--- a/apps/mobile/src/screens/units/MyHomeScreen.tsx
+++ b/apps/mobile/src/screens/units/MyHomeScreen.tsx
@@ -1,0 +1,385 @@
+import React, { useState, useCallback, useEffect } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  RefreshControl,
+  StyleSheet,
+} from 'react-native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { Card } from '../../components/Card'
+import { Button } from '../../components/Button'
+import { LoadingSpinner } from '../../components/LoadingSpinner'
+import { Toast } from '../../components/Toast'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
+import {
+  getMemberUnits,
+  MemberOwnership,
+  MemberOccupancy,
+  MemberUnitsResponse,
+} from '../../services/units'
+import { getApiErrorCode } from '../../services/api'
+import { getErrorMessage } from '../../utils/errorMessages'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'MyHome'>
+
+const OWNERSHIP_LABEL: Record<string, string> = {
+  PRIMARY_OWNER: 'Primary Owner',
+  CO_OWNER: 'Co-owner',
+}
+
+const OWNERSHIP_COLORS: Record<string, { bg: string; text: string }> = {
+  PRIMARY_OWNER: { bg: '#ede9fe', text: Colors.primary },
+  CO_OWNER: { bg: '#e0e7ff', text: '#6366f1' },
+}
+
+const OCCUPANCY_LABEL: Record<string, string> = {
+  OWNER_RESIDENT: 'Owner Resident',
+  TENANT: 'Tenant',
+  FAMILY: 'Family',
+  CARETAKER: 'Caretaker',
+}
+
+const OCCUPANCY_COLORS: Record<string, { bg: string; text: string }> = {
+  OWNER_RESIDENT: { bg: '#dcfce7', text: Colors.success },
+  TENANT: { bg: '#fef3c7', text: '#d97706' },
+  FAMILY: { bg: '#e0f2fe', text: '#0284c7' },
+  CARETAKER: { bg: '#fce7f3', text: '#be185d' },
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-IN', {
+    day: 'numeric', month: 'short', year: 'numeric',
+  })
+}
+
+// Build unified flat cards from ownerships + occupancies
+interface FlatCard {
+  flatId: string
+  flatName: string
+  path: string | null
+  ownership: MemberOwnership | null
+  occupancy: MemberOccupancy | null
+}
+
+function buildFlatCards(data: MemberUnitsResponse): FlatCard[] {
+  const map = new Map<string, FlatCard>()
+
+  for (const o of data.ownerships) {
+    map.set(o.flatId, {
+      flatId: o.flatId,
+      flatName: o.flatName,
+      path: o.path,
+      ownership: o,
+      occupancy: null,
+    })
+  }
+
+  for (const o of data.occupancies) {
+    const existing = map.get(o.flatId)
+    if (existing) {
+      existing.occupancy = o
+    } else {
+      map.set(o.flatId, {
+        flatId: o.flatId,
+        flatName: o.flatName,
+        path: o.path,
+        ownership: null,
+        occupancy: o,
+      })
+    }
+  }
+
+  return Array.from(map.values())
+}
+
+export function MyHomeScreen({ route, navigation }: Props) {
+  const { societyId, memberId } = route.params
+  const { permissions } = useAuth()
+
+  const canViewOwn = permissions.includes('unit.view_own')
+
+  const [data, setData] = useState<MemberUnitsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+
+  const load = useCallback(async () => {
+    setError(null)
+    try {
+      const result = await getMemberUnits(societyId, memberId)
+      setData(result)
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      setError(getErrorMessage(code))
+    } finally {
+      setLoading(false)
+    }
+  }, [societyId, memberId])
+
+  useEffect(() => { load() }, [load])
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true)
+    await load()
+    setRefreshing(false)
+  }, [load])
+
+  if (!canViewOwn) {
+    return (
+      <ScreenWrapper>
+        <View style={styles.emptyFull}>
+          <Text style={styles.emptyTitle}>Access restricted</Text>
+          <Text style={styles.emptySub}>You don't have permission to view home details.</Text>
+        </View>
+      </ScreenWrapper>
+    )
+  }
+
+  if (loading) return <LoadingSpinner fullScreen />
+
+  if (error || !data) {
+    return (
+      <ScreenWrapper>
+        <View style={styles.errorState}>
+          <Text style={styles.errorText}>{error ?? 'Could not load home details.'}</Text>
+          <Button label="Retry" onPress={load} style={styles.retryBtn} />
+        </View>
+      </ScreenWrapper>
+    )
+  }
+
+  const flatCards = buildFlatCards(data)
+
+  if (flatCards.length === 0) {
+    return (
+      <ScreenWrapper>
+        <View style={styles.emptyFull}>
+          <Text style={styles.emptyIcon}>🏠</Text>
+          <Text style={styles.emptyTitle}>No unit assigned yet</Text>
+          <Text style={styles.emptySub}>Contact your admin to get a unit assigned to you.</Text>
+        </View>
+        {toast ? (
+          <Toast message={toast.message} type={toast.type} visible={!!toast} onHide={() => setToast(null)} />
+        ) : null}
+      </ScreenWrapper>
+    )
+  }
+
+  return (
+    <ScreenWrapper scroll={false}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={Colors.primary}
+            colors={[Colors.primary]}
+          />
+        }
+      >
+        {flatCards.map((flat) => (
+          <FlatSection
+            key={flat.flatId}
+            flat={flat}
+            onViewDetail={() =>
+              navigation.navigate('UnitDetail', {
+                societyId,
+                unitId: flat.flatId,
+                unitName: flat.flatName,
+              })
+            }
+          />
+        ))}
+      </ScrollView>
+
+      {toast ? (
+        <Toast message={toast.message} type={toast.type} visible={!!toast} onHide={() => setToast(null)} />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── Flat section component ───────────────────────────────────────────────────
+
+interface FlatSectionProps {
+  flat: FlatCard
+  onViewDetail: () => void
+}
+
+function FlatSection({ flat, onViewDetail }: FlatSectionProps) {
+  const { ownership, occupancy } = flat
+
+  const ownershipColors = ownership
+    ? (OWNERSHIP_COLORS[ownership.ownershipType] ?? { bg: Colors.border, text: Colors.subtle })
+    : null
+
+  const occupancyColors = occupancy
+    ? (OCCUPANCY_COLORS[occupancy.occupancyType] ?? { bg: Colors.border, text: Colors.subtle })
+    : null
+
+  return (
+    <View style={flatStyles.container}>
+      {/* Primary flat card */}
+      <Card style={flatStyles.card}>
+        <Text style={flatStyles.flatName}>{flat.flatName}</Text>
+        {flat.path ? <Text style={flatStyles.path}>{flat.path}</Text> : null}
+
+        <View style={flatStyles.badgeRow}>
+          {ownership && ownershipColors ? (
+            <View style={[flatStyles.badge, { backgroundColor: ownershipColors.bg }]}>
+              <Text style={[flatStyles.badgeText, { color: ownershipColors.text }]}>
+                {OWNERSHIP_LABEL[ownership.ownershipType] ?? ownership.ownershipType}
+              </Text>
+            </View>
+          ) : null}
+          {occupancy && occupancyColors ? (
+            <View style={[flatStyles.badge, { backgroundColor: occupancyColors.bg }]}>
+              <Text style={[flatStyles.badgeText, { color: occupancyColors.text }]}>
+                {OCCUPANCY_LABEL[occupancy.occupancyType] ?? occupancy.occupancyType}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+
+        <Button
+          label="View Full Details"
+          variant="secondary"
+          onPress={onViewDetail}
+          style={flatStyles.detailBtn}
+        />
+      </Card>
+
+      {/* Co-owners */}
+      {ownership && ownership.coOwners.length > 0 ? (
+        <View style={flatStyles.section}>
+          <Text style={flatStyles.sectionTitle}>CO-OWNERS</Text>
+          <Card style={flatStyles.listCard}>
+            {ownership.coOwners.map((co, index) => {
+              const colors = OWNERSHIP_COLORS[co.ownershipType] ?? { bg: Colors.border, text: Colors.subtle }
+              return (
+                <React.Fragment key={index}>
+                  <View style={flatStyles.listRow}>
+                    <Text style={flatStyles.listName}>{co.name}</Text>
+                    <View style={[flatStyles.badge, { backgroundColor: colors.bg }]}>
+                      <Text style={[flatStyles.badgeText, { color: colors.text }]}>
+                        {OWNERSHIP_LABEL[co.ownershipType] ?? co.ownershipType}
+                      </Text>
+                    </View>
+                  </View>
+                  {index < ownership.coOwners.length - 1 ? <View style={flatStyles.divider} /> : null}
+                </React.Fragment>
+              )
+            })}
+          </Card>
+        </View>
+      ) : null}
+
+      {/* Co-occupants */}
+      {occupancy && occupancy.coOccupants.length > 0 ? (
+        <View style={flatStyles.section}>
+          <Text style={flatStyles.sectionTitle}>CO-OCCUPANTS</Text>
+          <Card style={flatStyles.listCard}>
+            {occupancy.coOccupants.map((co, index) => {
+              const colors = OCCUPANCY_COLORS[co.occupancyType] ?? { bg: Colors.border, text: Colors.subtle }
+              return (
+                <React.Fragment key={index}>
+                  <View style={flatStyles.listRow}>
+                    <Text style={flatStyles.listName}>{co.name}</Text>
+                    <View style={[flatStyles.badge, { backgroundColor: colors.bg }]}>
+                      <Text style={[flatStyles.badgeText, { color: colors.text }]}>
+                        {OCCUPANCY_LABEL[co.occupancyType] ?? co.occupancyType}
+                      </Text>
+                    </View>
+                  </View>
+                  {index < occupancy.coOccupants.length - 1 ? <View style={flatStyles.divider} /> : null}
+                </React.Fragment>
+              )
+            })}
+          </Card>
+        </View>
+      ) : null}
+
+      {/* Occupancy history for this flat */}
+      {occupancy ? (
+        <View style={flatStyles.section}>
+          <Text style={flatStyles.sectionTitle}>SINCE</Text>
+          <Text style={flatStyles.sinceDate}>{formatDate(occupancy.occupiedFrom)}</Text>
+        </View>
+      ) : ownership ? (
+        <View style={flatStyles.section}>
+          <Text style={flatStyles.sectionTitle}>OWNER SINCE</Text>
+          <Text style={flatStyles.sinceDate}>{formatDate(ownership.ownedFrom)}</Text>
+        </View>
+      ) : null}
+    </View>
+  )
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  content: {
+    padding: Spacing.screenPadding,
+    gap: Spacing.sectionGap,
+    paddingBottom: 40,
+  },
+  emptyFull: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 8,
+  },
+  emptyIcon: { fontSize: 48, marginBottom: 8 },
+  emptyTitle: { fontSize: 17, fontWeight: '600', color: Colors.text },
+  emptySub: { fontSize: 14, color: Colors.subtle, textAlign: 'center', lineHeight: 20 },
+  errorState: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 },
+  errorText: { fontSize: 15, color: Colors.subtle, textAlign: 'center' },
+  retryBtn: { paddingHorizontal: 32 },
+})
+
+const flatStyles = StyleSheet.create({
+  container: { gap: 12 },
+  card: { gap: 10 },
+  flatName: { fontSize: 22, fontWeight: '700', color: Colors.text },
+  path: { fontSize: 13, color: Colors.subtle, marginTop: -4 },
+  badgeRow: { flexDirection: 'row', gap: 8, flexWrap: 'wrap' },
+  badge: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 8,
+  },
+  badgeText: { fontSize: 12, fontWeight: '600' },
+  detailBtn: { marginTop: 4 },
+
+  // Sections inside flat card
+  section: { gap: 8 },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: Colors.subtle,
+    textTransform: 'uppercase',
+    letterSpacing: 0.7,
+  },
+  sinceDate: { fontSize: 14, color: Colors.text, fontWeight: '500' },
+
+  listCard: { padding: 0 },
+  listRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 14,
+    gap: 12,
+    minHeight: Spacing.minTapTarget,
+  },
+  listName: { fontSize: 14, fontWeight: '500', color: Colors.text, flex: 1 },
+  divider: { height: 1, backgroundColor: Colors.border, marginHorizontal: 14 },
+})

--- a/apps/mobile/src/screens/units/UnitDetailScreen.tsx
+++ b/apps/mobile/src/screens/units/UnitDetailScreen.tsx
@@ -1,0 +1,478 @@
+import React, { useState, useCallback, useEffect } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  RefreshControl,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { Card } from '../../components/Card'
+import { Button } from '../../components/Button'
+import { LoadingSpinner } from '../../components/LoadingSpinner'
+import { ConfirmSheet } from '../../components/ConfirmSheet'
+import { Toast } from '../../components/Toast'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
+import {
+  getUnit,
+  endOwnership,
+  endOccupancy,
+  UnitDetail,
+  UnitOwner,
+  UnitOccupant,
+} from '../../services/units'
+import { getApiErrorCode } from '../../services/api'
+import { getErrorMessage } from '../../utils/errorMessages'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'UnitDetail'>
+
+const OWNERSHIP_LABEL: Record<string, string> = {
+  PRIMARY_OWNER: 'Primary Owner',
+  CO_OWNER: 'Co-owner',
+}
+
+const OWNERSHIP_COLORS: Record<string, { bg: string; text: string }> = {
+  PRIMARY_OWNER: { bg: '#ede9fe', text: Colors.primary },
+  CO_OWNER: { bg: '#e0e7ff', text: '#6366f1' },
+}
+
+const OCCUPANCY_LABEL: Record<string, string> = {
+  OWNER_RESIDENT: 'Owner Resident',
+  TENANT: 'Tenant',
+  FAMILY: 'Family',
+  CARETAKER: 'Caretaker',
+}
+
+const OCCUPANCY_COLORS: Record<string, { bg: string; text: string }> = {
+  OWNER_RESIDENT: { bg: '#dcfce7', text: Colors.success },
+  TENANT: { bg: '#fef3c7', text: '#d97706' },
+  FAMILY: { bg: '#e0f2fe', text: '#0284c7' },
+  CARETAKER: { bg: '#fce7f3', text: '#be185d' },
+}
+
+function formatPhone(phone: string): string {
+  const d = phone.replace(/\D/g, '')
+  if (d.length === 12 && d.startsWith('91')) {
+    const local = d.slice(2)
+    return `+91 ${local.slice(0, 5)} ${local.slice(5)}`
+  }
+  return phone
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-IN', {
+    day: 'numeric', month: 'short', year: 'numeric',
+  })
+}
+
+type PendingDelete =
+  | { kind: 'ownership'; id: string; name: string }
+  | { kind: 'occupancy'; id: string; name: string }
+
+export function UnitDetailScreen({ route, navigation }: Props) {
+  const { societyId, unitId } = route.params
+  const { permissions } = useAuth()
+
+  const canAssign = permissions.includes('unit.assign')
+
+  const [unit, setUnit] = useState<UnitDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const [historyExpanded, setHistoryExpanded] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null)
+  const [deleteLoading, setDeleteLoading] = useState(false)
+
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+
+  const load = useCallback(async () => {
+    setError(null)
+    try {
+      const data = await getUnit(societyId, unitId)
+      setUnit(data)
+      navigation.setOptions({ title: data.name })
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      setError(getErrorMessage(code))
+    } finally {
+      setLoading(false)
+    }
+  }, [societyId, unitId, navigation])
+
+  useEffect(() => { load() }, [load])
+
+  const onRefresh = useCallback(async () => {
+    setRefreshing(true)
+    await load()
+    setRefreshing(false)
+  }, [load])
+
+  async function handleDeleteConfirm() {
+    if (!pendingDelete || !unit) return
+    setDeleteLoading(true)
+    try {
+      if (pendingDelete.kind === 'ownership') {
+        await endOwnership(societyId, unit.id, pendingDelete.id)
+        setToast({ message: 'Ownership ended.', type: 'success' })
+      } else {
+        await endOccupancy(societyId, unit.id, pendingDelete.id)
+        setToast({ message: 'Occupancy ended.', type: 'success' })
+      }
+      setPendingDelete(null)
+      await load()
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      setPendingDelete(null)
+      setToast({ message: getErrorMessage(code), type: 'error' })
+    } finally {
+      setDeleteLoading(false)
+    }
+  }
+
+  if (loading) return <LoadingSpinner fullScreen />
+
+  if (error || !unit) {
+    return (
+      <ScreenWrapper>
+        <View style={styles.errorState}>
+          <Text style={styles.errorText}>{error ?? 'Unit not found.'}</Text>
+          <Button label="Retry" onPress={load} style={styles.retryBtn} />
+        </View>
+      </ScreenWrapper>
+    )
+  }
+
+  const meta: string[] = []
+  if (unit.bhk) meta.push(`${unit.bhk} BHK`)
+  if (unit.floor != null) meta.push(`Floor ${unit.floor}`)
+  if (unit.area) meta.push(`${unit.area} sq.ft`)
+
+  return (
+    <ScreenWrapper scroll={false}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={onRefresh}
+            tintColor={Colors.primary}
+            colors={[Colors.primary]}
+          />
+        }
+      >
+        {/* ── Flat info card ── */}
+        <Card style={styles.flatCard}>
+          <View style={styles.flatHeader}>
+            <Text style={styles.flatName}>{unit.name}</Text>
+            {unit.isVacant ? (
+              <View style={styles.vacantBadge}>
+                <Text style={styles.vacantBadgeText}>Vacant</Text>
+              </View>
+            ) : null}
+          </View>
+          {unit.path ? (
+            <Text style={styles.flatPath}>{unit.path}</Text>
+          ) : null}
+          {meta.length > 0 ? (
+            <Text style={styles.flatMeta}>{meta.join(' · ')}</Text>
+          ) : null}
+        </Card>
+
+        {/* ── Owners ── */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>OWNERS</Text>
+            {canAssign ? (
+              <TouchableOpacity
+                onPress={() => navigation.navigate('MemberList', { societyId })}
+                hitSlop={12}
+              >
+                <Text style={styles.addBtn}>+ Add Owner</Text>
+              </TouchableOpacity>
+            ) : null}
+          </View>
+          <Card style={styles.listCard}>
+            {unit.owners.length > 0 ? (
+              unit.owners.map((owner, index) => (
+                <React.Fragment key={owner.id}>
+                  <PersonRow
+                    name={owner.name}
+                    phone={owner.phone}
+                    badgeLabel={OWNERSHIP_LABEL[owner.ownershipType] ?? owner.ownershipType}
+                    badgeColors={OWNERSHIP_COLORS[owner.ownershipType] ?? { bg: Colors.border, text: Colors.subtle }}
+                    isPrimary={owner.isPrimary}
+                    canEnd={canAssign}
+                    onEnd={() => setPendingDelete({ kind: 'ownership', id: owner.id, name: owner.name })}
+                  />
+                  {index < unit.owners.length - 1 ? <View style={styles.divider} /> : null}
+                </React.Fragment>
+              ))
+            ) : (
+              <Text style={styles.emptyRow}>No owners assigned</Text>
+            )}
+          </Card>
+        </View>
+
+        {/* ── Current Occupants ── */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>CURRENT OCCUPANTS</Text>
+            {canAssign ? (
+              <TouchableOpacity
+                onPress={() => navigation.navigate('MemberList', { societyId })}
+                hitSlop={12}
+              >
+                <Text style={styles.addBtn}>+ Add Occupant</Text>
+              </TouchableOpacity>
+            ) : null}
+          </View>
+          <Card style={styles.listCard}>
+            {unit.currentOccupants.length > 0 ? (
+              unit.currentOccupants.map((occ, index) => (
+                <React.Fragment key={occ.id}>
+                  <PersonRow
+                    name={occ.name}
+                    phone={occ.phone}
+                    badgeLabel={OCCUPANCY_LABEL[occ.occupancyType] ?? occ.occupancyType}
+                    badgeColors={OCCUPANCY_COLORS[occ.occupancyType] ?? { bg: Colors.border, text: Colors.subtle }}
+                    isPrimary={occ.isPrimary}
+                    canEnd={canAssign}
+                    onEnd={() => setPendingDelete({ kind: 'occupancy', id: occ.id, name: occ.name })}
+                  />
+                  {index < unit.currentOccupants.length - 1 ? <View style={styles.divider} /> : null}
+                </React.Fragment>
+              ))
+            ) : (
+              <Text style={styles.emptyRow}>No current occupants</Text>
+            )}
+          </Card>
+        </View>
+
+        {/* ── Occupancy History ── */}
+        {unit.occupancyHistory.length > 0 ? (
+          <View style={styles.section}>
+            <TouchableOpacity
+              onPress={() => setHistoryExpanded((v) => !v)}
+              style={styles.sectionHeader}
+              hitSlop={8}
+            >
+              <Text style={styles.sectionTitle}>OCCUPANCY HISTORY</Text>
+              <Text style={styles.expandChevron}>{historyExpanded ? '▲' : '▼'}</Text>
+            </TouchableOpacity>
+            {historyExpanded ? (
+              <Card style={styles.listCard}>
+                {unit.occupancyHistory.map((entry, index) => (
+                  <React.Fragment key={index}>
+                    <View style={styles.historyRow}>
+                      <View style={styles.historyLeft}>
+                        <Text style={styles.historyName}>{entry.name}</Text>
+                        <View style={[
+                          styles.badge,
+                          { backgroundColor: (OCCUPANCY_COLORS[entry.occupancyType] ?? { bg: Colors.border }).bg },
+                        ]}>
+                          <Text style={[
+                            styles.badgeText,
+                            { color: (OCCUPANCY_COLORS[entry.occupancyType] ?? { text: Colors.subtle }).text },
+                          ]}>
+                            {OCCUPANCY_LABEL[entry.occupancyType] ?? entry.occupancyType}
+                          </Text>
+                        </View>
+                      </View>
+                      <View style={styles.historyRight}>
+                        <Text style={styles.historyDate}>{formatDate(entry.occupiedFrom)}</Text>
+                        <Text style={styles.historyDateSub}>to {formatDate(entry.occupiedUntil)}</Text>
+                      </View>
+                    </View>
+                    {index < unit.occupancyHistory.length - 1 ? <View style={styles.divider} /> : null}
+                  </React.Fragment>
+                ))}
+              </Card>
+            ) : null}
+          </View>
+        ) : null}
+      </ScrollView>
+
+      {/* Delete confirmation */}
+      {pendingDelete ? (
+        <ConfirmSheet
+          visible={!!pendingDelete}
+          title={pendingDelete.kind === 'ownership' ? 'End ownership?' : 'End occupancy?'}
+          message={`This will end ${pendingDelete.name}'s ${pendingDelete.kind} of this unit.`}
+          confirmLabel={pendingDelete.kind === 'ownership' ? 'End Ownership' : 'End Occupancy'}
+          loading={deleteLoading}
+          onConfirm={handleDeleteConfirm}
+          onClose={() => setPendingDelete(null)}
+        />
+      ) : null}
+
+      {toast ? (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          visible={!!toast}
+          onHide={() => setToast(null)}
+        />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── Person row ───────────────────────────────────────────────────────────────
+
+interface PersonRowProps {
+  name: string
+  phone: string
+  badgeLabel: string
+  badgeColors: { bg: string; text: string }
+  isPrimary: boolean
+  canEnd: boolean
+  onEnd: () => void
+}
+
+function PersonRow({ name, phone, badgeLabel, badgeColors, isPrimary, canEnd, onEnd }: PersonRowProps) {
+  return (
+    <View style={personStyles.row}>
+      <View style={personStyles.left}>
+        <View style={personStyles.nameRow}>
+          <Text style={personStyles.name}>{name}</Text>
+          {isPrimary ? (
+            <View style={personStyles.primaryDot} />
+          ) : null}
+        </View>
+        <Text style={personStyles.phone}>{formatPhone(phone)}</Text>
+      </View>
+      <View style={personStyles.right}>
+        <View style={[personStyles.badge, { backgroundColor: badgeColors.bg }]}>
+          <Text style={[personStyles.badgeText, { color: badgeColors.text }]}>{badgeLabel}</Text>
+        </View>
+        {canEnd ? (
+          <TouchableOpacity onPress={onEnd} hitSlop={12}>
+            <Text style={personStyles.endBtn}>End</Text>
+          </TouchableOpacity>
+        ) : null}
+      </View>
+    </View>
+  )
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  content: {
+    padding: Spacing.screenPadding,
+    gap: Spacing.sectionGap,
+    paddingBottom: 40,
+  },
+
+  // Flat info card
+  flatCard: { gap: 6 },
+  flatHeader: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  flatName: { fontSize: 20, fontWeight: '700', color: Colors.text, flex: 1 },
+  vacantBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+    backgroundColor: '#fef3c7',
+  },
+  vacantBadgeText: { fontSize: 11, fontWeight: '600', color: '#d97706' },
+  flatPath: { fontSize: 13, color: Colors.subtle },
+  flatMeta: { fontSize: 13, color: Colors.subtle },
+
+  // Section
+  section: { gap: 10 },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: Colors.subtle,
+    textTransform: 'uppercase',
+    letterSpacing: 0.7,
+  },
+  addBtn: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: Colors.primary,
+  },
+  expandChevron: {
+    fontSize: 11,
+    color: Colors.subtle,
+  },
+
+  // List card
+  listCard: { padding: 0 },
+  divider: { height: 1, backgroundColor: Colors.border, marginHorizontal: 14 },
+  emptyRow: {
+    padding: 16,
+    fontSize: 14,
+    color: Colors.subtle,
+    fontStyle: 'italic',
+  },
+
+  // History row
+  historyRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    padding: 14,
+    gap: 12,
+  },
+  historyLeft: { flex: 1, gap: 6 },
+  historyName: { fontSize: 14, fontWeight: '600', color: Colors.text },
+  badge: {
+    alignSelf: 'flex-start',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+  },
+  badgeText: { fontSize: 11, fontWeight: '600' },
+  historyRight: { alignItems: 'flex-end', gap: 3 },
+  historyDate: { fontSize: 12, fontWeight: '500', color: Colors.text },
+  historyDateSub: { fontSize: 11, color: Colors.subtle },
+
+  // Error
+  errorState: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 16 },
+  errorText: { fontSize: 15, color: Colors.subtle, textAlign: 'center' },
+  retryBtn: { paddingHorizontal: 32 },
+})
+
+const personStyles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: 14,
+    gap: 12,
+    minHeight: Spacing.minTapTarget,
+  },
+  left: { flex: 1, gap: 3 },
+  nameRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  name: { fontSize: 14, fontWeight: '600', color: Colors.text },
+  primaryDot: {
+    width: 7,
+    height: 7,
+    borderRadius: 3.5,
+    backgroundColor: Colors.primary,
+  },
+  phone: { fontSize: 12, color: Colors.subtle },
+  right: { alignItems: 'flex-end', gap: 6 },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+  },
+  badgeText: { fontSize: 11, fontWeight: '600' },
+  endBtn: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: Colors.error,
+  },
+})

--- a/apps/mobile/src/screens/units/UnitDetailScreen.tsx
+++ b/apps/mobile/src/screens/units/UnitDetailScreen.tsx
@@ -149,7 +149,7 @@ export function UnitDetailScreen({ route, navigation }: Props) {
   }
 
   const meta: string[] = []
-  if (unit.bhk) meta.push(`${unit.bhk} BHK`)
+  if (unit.bhk) meta.push(`${unit.bhk}`)
   if (unit.floor != null) meta.push(`Floor ${unit.floor}`)
   if (unit.area) meta.push(`${unit.area} sq.ft`)
 

--- a/apps/mobile/src/screens/units/UnitInventoryScreen.tsx
+++ b/apps/mobile/src/screens/units/UnitInventoryScreen.tsx
@@ -1,0 +1,334 @@
+import React, { useState, useCallback, useRef, useEffect } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  RefreshControl,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+} from 'react-native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { useFocusEffect } from '@react-navigation/native'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { LoadingSpinner } from '../../components/LoadingSpinner'
+import { Toast } from '../../components/Toast'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
+import {
+  listUnits,
+  UnitListItem,
+  UnitStatusFilter,
+} from '../../services/units'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'UnitInventory'>
+
+type FilterValue = 'ALL' | UnitStatusFilter
+
+const FILTERS: { label: string; value: FilterValue }[] = [
+  { label: 'All', value: 'ALL' },
+  { label: 'Occupied', value: 'occupied' },
+  { label: 'Vacant', value: 'vacant' },
+]
+
+const OCCUPANCY_LABEL: Record<string, string> = {
+  OWNER_RESIDENT: 'Owner',
+  TENANT: 'Tenant',
+  FAMILY: 'Family',
+  CARETAKER: 'Caretaker',
+}
+
+export function UnitInventoryScreen({ route, navigation }: Props) {
+  const { societyId } = route.params
+  const { permissions } = useAuth()
+
+  const canViewAll = permissions.includes('unit.view_all')
+
+  const [filter, setFilter] = useState<FilterValue>('ALL')
+  const [units, setUnits] = useState<UnitListItem[]>([])
+  const [stats, setStats] = useState({ total: 0, occupied: 0, vacant: 0 })
+  const [isLoading, setIsLoading] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => { isMounted.current = false }
+  }, [])
+
+  const load = useCallback(
+    async (reset = true) => {
+      if (!canViewAll) return
+      try {
+        if (reset) setIsLoading(true)
+        const params = filter !== 'ALL' ? { status: filter as UnitStatusFilter } : {}
+        const result = await listUnits(societyId, params)
+        if (!isMounted.current) return
+        setUnits(result.units)
+        setStats({ total: result.total, occupied: result.occupied, vacant: result.vacant })
+      } catch {
+        if (isMounted.current) {
+          setToast({ message: 'Could not load units. Pull to retry.', type: 'error' })
+        }
+      } finally {
+        if (isMounted.current) {
+          setIsLoading(false)
+          setIsRefreshing(false)
+        }
+      }
+    },
+    [societyId, filter, canViewAll],
+  )
+
+  useFocusEffect(
+    useCallback(() => {
+      load(true)
+    }, [load]),
+  )
+
+  const onRefresh = useCallback(() => {
+    setIsRefreshing(true)
+    load(false)
+  }, [load])
+
+  if (!canViewAll) {
+    return (
+      <ScreenWrapper>
+        <View style={styles.emptyFull}>
+          <Text style={styles.emptyTitle}>Access restricted</Text>
+          <Text style={styles.emptySub}>You don't have permission to view the unit inventory.</Text>
+        </View>
+      </ScreenWrapper>
+    )
+  }
+
+  if (isLoading) return <LoadingSpinner fullScreen />
+
+  const renderItem = ({ item }: { item: UnitListItem }) => (
+    <Pressable
+      onPress={() =>
+        navigation.navigate('UnitDetail', {
+          societyId,
+          unitId: item.id,
+          unitName: item.name,
+        })
+      }
+      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+    >
+      <View style={styles.rowContent}>
+        <View style={styles.rowTop}>
+          <Text style={styles.flatName}>{item.name}</Text>
+          {item.isVacant ? (
+            <View style={styles.vacantBadge}>
+              <Text style={styles.vacantBadgeText}>Vacant</Text>
+            </View>
+          ) : null}
+        </View>
+        {item.path ? (
+          <Text style={styles.path} numberOfLines={1}>{item.path}</Text>
+        ) : null}
+        <View style={styles.rowMeta}>
+          {item.primaryOwner ? (
+            <Text style={styles.metaText}>Owner: {item.primaryOwner}</Text>
+          ) : null}
+          {item.primaryOccupant ? (
+            <Text style={styles.metaText}>
+              Occupant: {item.primaryOccupant}
+              {item.occupancyType
+                ? ` · ${OCCUPANCY_LABEL[item.occupancyType] ?? item.occupancyType}`
+                : null}
+            </Text>
+          ) : null}
+          {!item.primaryOwner && !item.primaryOccupant ? (
+            <Text style={styles.metaTextSubtle}>No owner or occupant assigned</Text>
+          ) : null}
+        </View>
+      </View>
+      <Text style={styles.chevron}>›</Text>
+    </Pressable>
+  )
+
+  return (
+    <ScreenWrapper scroll={false} style={styles.wrapper}>
+      {/* Stats row */}
+      <View style={styles.statsRow}>
+        <View style={styles.statItem}>
+          <Text style={styles.statNumber}>{stats.total}</Text>
+          <Text style={styles.statLabel}>Total</Text>
+        </View>
+        <View style={styles.statDivider} />
+        <View style={styles.statItem}>
+          <Text style={[styles.statNumber, { color: Colors.success }]}>{stats.occupied}</Text>
+          <Text style={styles.statLabel}>Occupied</Text>
+        </View>
+        <View style={styles.statDivider} />
+        <View style={styles.statItem}>
+          <Text style={[styles.statNumber, { color: '#d97706' }]}>{stats.vacant}</Text>
+          <Text style={styles.statLabel}>Vacant</Text>
+        </View>
+      </View>
+
+      {/* Filter chips */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.chips}
+        style={styles.chipBar}
+      >
+        {FILTERS.map((f) => (
+          <Pressable
+            key={f.value}
+            onPress={() => setFilter(f.value)}
+            style={[styles.chip, filter === f.value && styles.chipActive]}
+          >
+            <Text style={[styles.chipText, filter === f.value && styles.chipTextActive]}>
+              {f.label}
+            </Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+
+      {/* Unit list */}
+      <FlatList
+        data={units}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={onRefresh}
+            tintColor={Colors.primary}
+            colors={[Colors.primary]}
+          />
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyFull}>
+            <Text style={styles.emptyTitle}>No units</Text>
+            <Text style={styles.emptySub}>
+              {filter === 'ALL' ? 'No units in this society.' : `No ${filter} units.`}
+            </Text>
+          </View>
+        }
+        contentContainerStyle={units.length === 0 ? styles.emptyContainer : undefined}
+        style={styles.list}
+      />
+
+      {toast ? (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          visible={!!toast}
+          onHide={() => setToast(null)}
+        />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  wrapper: { backgroundColor: Colors.background },
+
+  // Stats
+  statsRow: {
+    flexDirection: 'row',
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    paddingVertical: 14,
+  },
+  statItem: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 2,
+  },
+  statDivider: {
+    width: 1,
+    backgroundColor: Colors.border,
+  },
+  statNumber: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: Colors.primary,
+  },
+  statLabel: {
+    fontSize: 12,
+    color: Colors.subtle,
+    fontWeight: '500',
+  },
+
+  // Filter chips
+  chipBar: { flexGrow: 0, flexShrink: 0 },
+  chips: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 12,
+    gap: 8,
+    alignItems: 'center',
+  },
+  chip: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    backgroundColor: Colors.surface,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  chipActive: {
+    backgroundColor: Colors.primary,
+    borderColor: Colors.primary,
+  },
+  chipText: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: Colors.subtle,
+  },
+  chipTextActive: { color: Colors.surface },
+
+  // List
+  list: { flex: 1 },
+
+  // Row
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 14,
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    gap: 12,
+    minHeight: Spacing.minTapTarget,
+  },
+  rowPressed: { backgroundColor: Colors.background },
+  rowContent: { flex: 1, gap: 4 },
+  rowTop: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  flatName: { fontSize: 15, fontWeight: '600', color: Colors.text, flex: 1 },
+  vacantBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 6,
+    backgroundColor: '#fef3c7',
+  },
+  vacantBadgeText: { fontSize: 11, fontWeight: '600', color: '#d97706' },
+  path: { fontSize: 12, color: Colors.subtle },
+  rowMeta: { gap: 2 },
+  metaText: { fontSize: 12, color: Colors.subtle },
+  metaTextSubtle: { fontSize: 12, color: Colors.border, fontStyle: 'italic' },
+  chevron: { fontSize: 22, color: Colors.subtle, lineHeight: 26 },
+
+  // Empty
+  emptyContainer: { flexGrow: 1 },
+  emptyFull: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 8,
+  },
+  emptyTitle: { fontSize: 17, fontWeight: '600', color: Colors.text },
+  emptySub: { fontSize: 14, color: Colors.subtle, textAlign: 'center' },
+})

--- a/apps/mobile/src/services/units.ts
+++ b/apps/mobile/src/services/units.ts
@@ -1,0 +1,174 @@
+import api from './api'
+
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+export type OwnershipType = 'PRIMARY_OWNER' | 'CO_OWNER'
+export type OccupancyType = 'OWNER_RESIDENT' | 'TENANT' | 'FAMILY' | 'CARETAKER'
+
+// ─── List Units (inventory) ───────────────────────────────────────────────────
+
+export interface UnitListItem {
+  id: string
+  name: string
+  code: string | null
+  path: string | null
+  metadata: Record<string, unknown> | null
+  isVacant: boolean
+  primaryOwner: string | null
+  primaryOccupant: string | null
+  occupancyType: OccupancyType | null
+}
+
+export interface ListUnitsResponse {
+  units: UnitListItem[]
+  total: number
+  occupied: number
+  vacant: number
+}
+
+export type UnitStatusFilter = 'vacant' | 'occupied'
+
+export async function listUnits(
+  societyId: string,
+  params?: { status?: UnitStatusFilter },
+): Promise<ListUnitsResponse> {
+  const res = await api.get(`/societies/${societyId}/units`, { params })
+  return res.data.data
+}
+
+// ─── Unit Detail ──────────────────────────────────────────────────────────────
+
+export interface UnitOwner {
+  id: string
+  name: string
+  phone: string
+  ownershipType: OwnershipType
+  isPrimary: boolean
+  ownedFrom: string
+}
+
+export interface UnitOccupant {
+  id: string
+  name: string
+  phone: string
+  occupancyType: OccupancyType
+  isPrimary: boolean
+  occupiedFrom: string
+}
+
+export interface UnitHistoryEntry {
+  name: string
+  occupancyType: OccupancyType
+  occupiedFrom: string
+  occupiedUntil: string
+}
+
+export interface UnitDetail {
+  id: string
+  name: string
+  code: string | null
+  path: string | null
+  floor: number | null
+  bhk: number | null
+  area: number | null
+  isVacant: boolean
+  owners: UnitOwner[]
+  currentOccupants: UnitOccupant[]
+  occupancyHistory: UnitHistoryEntry[]
+}
+
+export async function getUnit(societyId: string, nodeId: string): Promise<UnitDetail> {
+  const res = await api.get(`/societies/${societyId}/units/${nodeId}`)
+  return res.data.data
+}
+
+// ─── Ownership ────────────────────────────────────────────────────────────────
+
+export interface AssignOwnershipInput {
+  userId: string
+  ownershipType: OwnershipType
+  isPrimary?: boolean
+}
+
+export async function assignOwnership(
+  societyId: string,
+  nodeId: string,
+  data: AssignOwnershipInput,
+) {
+  const res = await api.post(`/societies/${societyId}/units/${nodeId}/ownership`, data)
+  return res.data.data
+}
+
+export async function endOwnership(
+  societyId: string,
+  nodeId: string,
+  ownershipId: string,
+) {
+  const res = await api.delete(
+    `/societies/${societyId}/units/${nodeId}/ownership/${ownershipId}`,
+  )
+  return res.data.data
+}
+
+// ─── Occupancy ────────────────────────────────────────────────────────────────
+
+export interface AssignOccupancyInput {
+  userId: string
+  occupancyType: OccupancyType
+  isPrimary?: boolean
+}
+
+export async function assignOccupancy(
+  societyId: string,
+  nodeId: string,
+  data: AssignOccupancyInput,
+) {
+  const res = await api.post(`/societies/${societyId}/units/${nodeId}/occupancy`, data)
+  return res.data.data
+}
+
+export async function endOccupancy(
+  societyId: string,
+  nodeId: string,
+  occupancyId: string,
+) {
+  const res = await api.delete(
+    `/societies/${societyId}/units/${nodeId}/occupancy/${occupancyId}`,
+  )
+  return res.data.data
+}
+
+// ─── My Home (member units) ───────────────────────────────────────────────────
+
+export interface MemberOwnership {
+  flatId: string
+  flatName: string
+  path: string | null
+  ownershipType: OwnershipType
+  isPrimary: boolean
+  ownedFrom: string
+  coOwners: { name: string; ownershipType: OwnershipType }[]
+}
+
+export interface MemberOccupancy {
+  flatId: string
+  flatName: string
+  path: string | null
+  occupancyType: OccupancyType
+  isPrimary: boolean
+  occupiedFrom: string
+  coOccupants: { name: string; occupancyType: OccupancyType }[]
+}
+
+export interface MemberUnitsResponse {
+  ownerships: MemberOwnership[]
+  occupancies: MemberOccupancy[]
+}
+
+export async function getMemberUnits(
+  societyId: string,
+  memberId: string,
+): Promise<MemberUnitsResponse> {
+  const res = await api.get(`/societies/${societyId}/members/${memberId}/units`)
+  return res.data.data
+}

--- a/apps/mobile/src/utils/errorMessages.ts
+++ b/apps/mobile/src/utils/errorMessages.ts
@@ -52,6 +52,10 @@ const ERROR_MAP: Record<string, string> = {
   cannot_resolve_others: 'You can only resolve your own complaints.',
   complaint_not_found: 'Complaint not found.',
 
+  // Units
+  already_owner: 'This member already has ownership of this unit.',
+  cannot_self_assign_occupied: 'This unit already has an owner. You cannot assign yourself to it.',
+
   // Members
   invalid_status: 'Invalid status filter.',
   cannot_deactivate_self: 'You cannot remove yourself.',

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -287,7 +287,7 @@ Full My Home screen shows all linked flats.
 flats get full detail in My Home screen.
 
 ## 030 — Ownership self-assignment rules
-**Date:** 2026-04-13
+**Date:** 2026-04-15
 **Decision:**
 Self-assignment to vacant flat allowed — builder needs to assign his own unsold flats, single admin needs
 to assign their own flat when no one else can.
@@ -307,3 +307,57 @@ caretakers and family members legitimately added.
 Builder has no one above them to assign their flats.
 Single-admin societies have same problem.
 Audit log tracks all assignments with actorId.
+
+**Known V1 gap — occupancy self-assign:**
+Builder/Admin can self-assign as occupant (CARETAKER, OWNER_RESIDENT etc) to any flat including occupied ones. This is intentional for V1 — occupancy is more fluid than ownership. Ownership is the legally sensitive record.
+V2: add same self-assign restriction to occupancy if pilot feedback indicates abuse.
+
+**Known V1 gaps with severity:**
+
+MEDIUM (mitigated by audit log):
+- Admin can end any ownership/occupancy silently
+  Affected party not notified
+  V2: push notifications on ownership changes
+
+LOW (acceptable for V1):
+- Occupancy self-assign not restricted
+- No document verification for ownership
+- No primary owner replacement prompt
+- No rate limiting on unit endpoints
+- AssignUnitScreen doesn't show existing assignment
+
+All gaps tracked. Audit log captures all changes
+with actorId. No critical or high severity gaps
+remaining for V1 pilot.
+
+## 031 — V1 trust model for unit management
+**Date:** **Date:** 2026-04-15
+
+V1 operates on a delegated trust model:
+  Builder has ultimate authority
+  Admin operates with builder's trust
+  Residents have read-only access to own flat
+
+This mirrors real Indian society management where
+the RWA secretary (admin) has physical access to
+all records. Vaastio digitizes this model.
+
+Known architectural limitation:
+  Owner cannot manage their own flat (read-only)
+  All changes go through admin/builder
+  This creates unnecessary admin dependency
+  
+V2: Add unit.manage_own permission for PRIMARY_OWNER
+  Allows owner to manage co-owners and occupants
+  of their own flat without admin intervention
+
+Abuse mitigation for V1:
+  All changes audit logged with actorId
+  Rogue changes visible to affected resident
+  in their My Home screen immediately
+  Builder can review and reverse any change
+
+Critical gap before scale:
+  Push notifications for ownership/occupancy changes
+  Must be implemented before >50 flat deployments
+  Residents currently rely on active app checking

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -285,3 +285,25 @@ flats regardless of who owns them.
 Full My Home screen shows all linked flats.
 **Reason:** Dashboard must stay clean. Members with multiple
 flats get full detail in My Home screen.
+
+## 030 — Ownership self-assignment rules
+**Date:** 2026-04-13
+**Decision:**
+Self-assignment to vacant flat allowed — builder needs to assign his own unsold flats, single admin needs
+to assign their own flat when no one else can.
+
+Self-assignment to flat with existing different owner blocked prevents rogue admin from silently adding
+themselves to occupied flats.
+
+Duplicate ownership by same person on same flat blocked. Occupancy self-assignment unrestricted for V1 —
+caretakers and family members legitimately added.
+
+**V2 additions planned (non-breaking):**
+- Push notification to existing owners when new owner/occupant added (additive — side effect only)
+- Builder approval for ownership assignments (additive — new status column + endpoint)
+- Document upload requirement for ownership (additive — transferDocRef already in schema, NOT SURE)
+
+**Why not fully block self-assignment:**
+Builder has no one above them to assign their flats.
+Single-admin societies have same problem.
+Audit log tracks all assignments with actorId.

--- a/docs/briefs/unit-assignment.md
+++ b/docs/briefs/unit-assignment.md
@@ -618,6 +618,23 @@ Gatekeeper tries to view unit details:
 Resident tries to view another member's flat:
 → 403 insufficient_permissions
 
+### Ownership Security Rules
+Self-assign to vacant flat: ALLOWED
+  Builder assigns himself to unsold flats.
+  Single admin assigns himself when no one else can.
+
+Self-assign to flat with existing different owner: BLOCKED
+  error: cannot_self_assign_occupied
+  Prevents rogue admin silently adding themselves.
+
+Duplicate ownership same person same flat: BLOCKED
+  error: already_owner
+  Prevents data corruption from double assignment.
+
+Occupancy self-assignment: ALLOWED
+  No restriction — caretakers and family members
+  legitimately live in flats.
+  
 ---
 
 ## Files To Create


### PR DESCRIPTION
### Mobile Screens (4 new)
- UnitInventoryScreen — list all units with vacancy status, filter chips
- UnitDetailScreen — owners, occupants, history, add/end actions
- AssignUnitScreen — searchable flat picker, ownership + occupancy assignment
- MyHomeScreen — resident's flat details, co-owners, co-occupants

### Backend Fixes
- Villa/Floor/Plot nodes now appear in unit assignment (ASSIGNABLE_TYPES)
- Prevent duplicate ownership by same person on same unit
- Prevent self-assigning to flat with existing different owner
- Self-assign to vacant flat still allowed (builder's unsold flats)
- OTP rate limit bypassed in development environment

### Mobile Fixes
- BHK display no longer doubles the label (2BHK not 2BHK BHK)
- AssignUnitScreen search placeholder updated for all node types
- Error screen has Sign Out button (no more stuck screens)
- Deactivated members see Access Removed screen not Create Society
- Create Society screen has Sign Out option
- Builder/Gatekeeper/Admin no longer show "No unit assigned" in member list

### Dashboard Updates
- Unit Inventory action (admin/builder only)
- My Home action (resident/co-resident only)

### Member Detail Updates
- Assign Unit button (admin/builder only)

### Services
- units.ts — all unit API calls typed

### Tests
- 188 total passing (2 new ownership security tests added)
- All 8 suites green

### Docs
- DECISIONS.md updated
- Unit assignment brief updated with security rules