### PR TITLE
visitor UX improvements and dashboard redesign

### DIFF
--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -339,9 +339,11 @@ export function DashboardScreen({ route, navigation }: Props) {
               {society.name}
             </Text>
             <View style={styles.metaRow}>
-              <Text style={styles.typePill}>
-                {SOCIETY_TYPE_LABEL[society.type] ?? society.type}
-              </Text>
+              {(role === 'Builder' || role === 'Admin') && (
+                <Text style={styles.typePill}>
+                  {SOCIETY_TYPE_LABEL[society.type] ?? society.type}
+                </Text>
+              )}
               {role ? <Text style={styles.rolePill}>{role}</Text> : null}
             </View>
           </View>

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -12,7 +12,6 @@ import {
 } from 'react-native'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { ScreenWrapper } from '../../components/ScreenWrapper'
-import { Card } from '../../components/Card'
 import { Button } from '../../components/Button'
 import { LoadingSpinner } from '../../components/LoadingSpinner'
 import { Toast } from '../../components/Toast'
@@ -23,6 +22,7 @@ import { useSociety } from '../../hooks/useSociety'
 import { updateProfile } from '../../services/auth'
 import { getApiErrorCode } from '../../services/api'
 import { getErrorMessage } from '../../utils/errorMessages'
+import { VisitorEntry, getActiveVisitors, getEntryLog } from '../../services/visitors'
 import { Colors } from '../../constants/colors'
 import { Spacing } from '../../constants/spacing'
 import { Ionicons } from '@expo/vector-icons'
@@ -110,6 +110,10 @@ export function DashboardScreen({ route, navigation }: Props) {
   const [isSaving, setIsSaving] = useState(false)
   const [layoutMode, setLayoutMode] = useState<'grid' | 'list'>('grid')
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' | 'info' } | null>(null)
+  const [activeCount, setActiveCount] = useState(0)
+  const [todayCount, setTodayCount] = useState(0)
+  const [pendingCount, setPendingCount] = useState(0)
+  const [pendingEntry, setPendingEntry] = useState<VisitorEntry | null>(null)
 
   function openProfile() {
     setProfileName(user?.name ?? '')
@@ -141,13 +145,35 @@ export function DashboardScreen({ route, navigation }: Props) {
     }
   }
 
+  const loadVisitorStats = useCallback(async () => {
+    if (permissions.includes('visitor.log')) {
+      const active = await getActiveVisitors(societyId)
+      setActiveCount(active.length)
+      const today = new Date().toISOString().split('T')[0]
+      const todayEntries = await getEntryLog(societyId, { date: today })
+      setTodayCount(todayEntries.length)
+      const pending = await getEntryLog(societyId, { status: 'PENDING' })
+      setPendingCount(pending.length)
+    }
+    if (permissions.includes('visitor.approve')) {
+      try {
+        const entries = await getEntryLog(societyId, { status: 'PENDING' })
+        const pending = entries.find(e => e.status === 'PENDING')
+        setPendingEntry(pending ?? null)
+      } catch {
+        // non-critical — fail silently
+      }
+    }
+  }, [societyId, permissions])
+
   useEffect(() => {
     load()
-  }, [load])
+    loadVisitorStats()
+  }, [load, loadVisitorStats])
 
   const onRefresh = useCallback(async () => {
-    await Promise.all([load(), loadUser()])
-  }, [load, loadUser])
+    await Promise.all([load(), loadUser(), loadVisitorStats()])
+  }, [load, loadUser, loadVisitorStats])
 
   const canCreateSociety = permissions.includes('society.create')
 
@@ -354,17 +380,59 @@ export function DashboardScreen({ route, navigation }: Props) {
           {society.address}, {society.city}, {society.state} – {society.pincode}
         </Text>
 
-        {/* Stats */}
-        <View style={styles.statsRow}>
-          <Card style={styles.statCard}>
-            <Text style={styles.statNumber}>{society.totalUnits}</Text>
-            <Text style={styles.statLabel}>Total Units</Text>
-          </Card>
-          <Card style={styles.statCard}>
-            <Text style={styles.statNumber}>{society.totalMembers}</Text>
-            <Text style={styles.statLabel}>Members</Text>
-          </Card>
-        </View>
+        {/* Stats — role-specific */}
+        {canLogVisitor ? (
+          <View style={styles.statsRow}>
+            <View style={styles.statCard}>
+              <Text style={styles.statNumber}>{activeCount}</Text>
+              <Text style={styles.statLabel}>Inside Now</Text>
+            </View>
+            <View style={styles.statCard}>
+              <Text style={styles.statNumber}>{todayCount}</Text>
+              <Text style={styles.statLabel}>Today's Entries</Text>
+            </View>
+            <View style={[styles.statCard, pendingCount > 0 && styles.statCardAlert]}>
+              <Text style={[styles.statNumber, pendingCount > 0 && styles.statNumberAlert]}>
+                {pendingCount}
+              </Text>
+              <Text style={[styles.statLabel, pendingCount > 0 && styles.statLabelAlert]}>
+                Awaiting Approval
+              </Text>
+            </View>
+          </View>
+        ) : !canManageMyVisitors ? (
+          <View style={styles.statsRow}>
+            <View style={styles.statCard}>
+              <Text style={styles.statNumber}>{society.totalUnits}</Text>
+              <Text style={styles.statLabel}>Total Units</Text>
+            </View>
+            <View style={styles.statCard}>
+              <Text style={styles.statNumber}>{society.totalMembers}</Text>
+              <Text style={styles.statLabel}>Members</Text>
+            </View>
+          </View>
+        ) : null}
+
+        {/* Pending visitor alert — residents only */}
+        {canManageMyVisitors && !canLogVisitor && pendingEntry && (
+          <Pressable
+            style={styles.pendingBanner}
+            onPress={() => navigation.navigate('VisitorApproval', {
+              societyId,
+              entryId: pendingEntry.id,
+            })}
+          >
+            <Ionicons name="notifications" size={20} color="#f97316" />
+            <View style={styles.pendingBannerText}>
+              <Text style={styles.pendingBannerTitle}>
+                {pendingEntry.visitorName} is waiting at your gate
+              </Text>
+              <Text style={styles.pendingBannerSub}>
+                Tap to approve or deny →
+              </Text>
+            </View>
+          </Pressable>
+        )}
 
         {/* Actions */}
         {hasAnyAction ? (
@@ -585,16 +653,50 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 18,
     gap: 4,
+    backgroundColor: Colors.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: Colors.border,
+  },
+  statCardAlert: {
+    backgroundColor: '#fff7ed',
+    borderColor: '#f97316',
+    borderWidth: 1,
   },
   statNumber: {
     fontSize: 28,
     fontWeight: '700',
     color: Colors.primary,
   },
+  statNumberAlert: { color: '#f97316' },
   statLabel: {
     fontSize: 13,
     color: Colors.subtle,
     fontWeight: '500',
+  },
+  statLabelAlert: { color: '#f97316' },
+  pendingBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    backgroundColor: '#fff7ed',
+    borderWidth: 1,
+    borderColor: '#f97316',
+    borderRadius: 12,
+    padding: 16,
+    marginHorizontal: 16,
+    marginBottom: 16,
+  },
+  pendingBannerText: { flex: 1 },
+  pendingBannerTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#92400e',
+  },
+  pendingBannerSub: {
+    fontSize: 12,
+    color: '#f97316',
+    marginTop: 2,
   },
 
   // Actions section

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -545,8 +545,10 @@ const styles = StyleSheet.create({
   typePill: {
     fontSize: 12,
     fontWeight: '500',
-    color: Colors.primary,
-    backgroundColor: '#ede9fe',
+    color: Colors.subtle,
+    backgroundColor: Colors.background,
+    borderWidth: 1,
+    borderColor: Colors.border,
     paddingHorizontal: 8,
     paddingVertical: 3,
     borderRadius: 6,

--- a/apps/mobile/src/screens/visitors/LogVisitorScreen.tsx
+++ b/apps/mobile/src/screens/visitors/LogVisitorScreen.tsx
@@ -93,7 +93,7 @@ export function LogVisitorScreen({ route, navigation }: Props) {
   useEffect(() => {
     listUnits(societyId)
       .then(res => setUnits(res.units))
-      .catch(() => setToast({ message: 'Failed to load flats', type: 'error' }))
+      .catch(() => setToast({ message: 'Failed to load units', type: 'error' }))
   }, [societyId])
 
   // Debounced Search
@@ -194,22 +194,33 @@ export function LogVisitorScreen({ route, navigation }: Props) {
     if (!selectedVisitor) return
 
     if (!selectedPreApproval && !selectedUnitId) {
-      setToast({ message: 'Please select a flat', type: 'error' })
+      setToast({ message: 'Please select a unit or area', type: 'error' })
       return
     }
+
+    const isCommonArea = selectedUnitId === '__society__'
 
     setIsLogging(true)
     try {
       const entry = await logEntry(societyId, selectedVisitor.id, {
-        unitId: selectedPreApproval ? selectedPreApproval.unitId : selectedUnitId!,
+        unitId: selectedPreApproval ? selectedPreApproval.unitId : (isCommonArea ? undefined : selectedUnitId!),
         purpose: purpose.trim() || undefined,
         vehicleNo: vehicleNo.trim() || undefined,
         photoUrl: photoBase64 || undefined,
         preApprovalId: selectedPreApproval?.id,
       })
 
-      // If frequent + no notify -> immediately allow
-      if (selectedVisitor.isFrequent && !notifyFrequent && entry.status === 'PENDING') {
+      // Common area: no resident to notify — fast-track allow + enter
+      if (isCommonArea) {
+        setCurrentEntry({ ...entry, flatName: 'Common Area' })
+        await allowEntry(societyId, entry.id)
+        setCurrentEntry(prev => prev ? { ...prev, status: 'ALLOWED' } : prev)
+        await markEntered(societyId, entry.id)
+        setCurrentEntry(prev => prev ? { ...prev, enteredAt: new Date().toISOString() } : prev)
+        setToast({ message: 'Common Area visitor — entry logged and allowed', type: 'success' })
+        setTimeout(() => navigation.replace('ActiveVisitors', { societyId }), 1500)
+      } else if (selectedVisitor.isFrequent && !notifyFrequent && entry.status === 'PENDING') {
+        // If frequent + no notify -> immediately allow
         setCurrentEntry(entry)
         await allowEntry(societyId, entry.id)
         setCurrentEntry(prev => prev ? { ...prev, status: 'ALLOWED' } : prev)
@@ -348,7 +359,7 @@ export function LogVisitorScreen({ route, navigation }: Props) {
 
             {/* Flat Picker */}
             <View style={styles.field}>
-              <Text style={styles.fieldLabel}>Which Flat? *</Text>
+              <Text style={styles.fieldLabel}>Which Unit / Area? *</Text>
               {selectedPreApproval ? (
                 <View style={[styles.pickerTrigger, styles.pickerDisabled]}>
                   <Text style={styles.pickerText}>{selectedPreApproval.flatName}</Text>
@@ -357,7 +368,7 @@ export function LogVisitorScreen({ route, navigation }: Props) {
               ) : (
                 <Pressable onPress={() => setShowUnitPicker(true)} style={styles.pickerTrigger}>
                   <Text style={[styles.pickerText, !selectedUnitId && styles.pickerPlaceholder]}>
-                    {selectedUnitId ? units.find(u => u.id === selectedUnitId)?.name : 'Select a flat'}
+                    {selectedUnitId === '__society__' ? 'Common Area / Society' : selectedUnitId ? units.find(u => u.id === selectedUnitId)?.name : 'Select unit or area'}
                   </Text>
                   <Text style={styles.pickerChevron}>›</Text>
                 </Pressable>
@@ -423,9 +434,12 @@ export function LogVisitorScreen({ route, navigation }: Props) {
 
         <BottomSheetPicker
           visible={showUnitPicker}
-          title="Select Flat"
+          title="Select Unit or Area"
           searchable
-          options={units.map(u => ({ label: `${u.name} ${u.primaryOccupant ? `(${u.primaryOccupant})` : ''}`, value: u.id }))}
+          options={[
+            { label: 'Common Area / Society', value: '__society__' },
+            ...units.map(u => ({ label: `${u.name} ${u.primaryOccupant ? `(${u.primaryOccupant})` : ''}`, value: u.id }))
+          ]}
           selected={selectedUnitId}
           onSelect={(val) => {
             setSelectedUnitId(val as string)


### PR DESCRIPTION
### Visitor UX
- Add "Common Area / Society" option to unit picker
  for visitors not coming to a specific flat
- Common area visitors auto-allowed and entered instantly
- Fix UI labels: "flat" → "unit/area" for all society types
- Searchable unit picker title updated
- Auto-select flat when frequent visitor tapped

### Dashboard Redesign
- Gatekeeper: Inside Now, Today's Entries, Awaiting Approval
  (Awaiting Approval highlighted orange when > 0)
- Resident/Co-resident: no stats, pending visitor alert banner
  (taps directly to VisitorApprovalScreen)
- Builder/Admin: unchanged (Total Units + Total Members)

### Polish
- Society type pill hidden for Gatekeeper and Resident roles
- typePill style changed to ghost/outlined (less dominant)
- Error messages updated from "flats" to "units"