### PR TITLE
feat: notification inbox

### DIFF
--- a/apps/api/prisma/migrations/20260519010947_add_notification_inbox/migration.sql
+++ b/apps/api/prisma/migrations/20260519010947_add_notification_inbox/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "user_notifications" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "orgId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "screen" TEXT,
+    "data" JSONB,
+    "isRead" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_notifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "user_notifications_userId_isRead_idx" ON "user_notifications"("userId", "isRead");
+
+-- CreateIndex
+CREATE INDEX "user_notifications_userId_createdAt_idx" ON "user_notifications"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "user_notifications" ADD CONSTRAINT "user_notifications_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "user_notifications" ADD CONSTRAINT "user_notifications_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "organizations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -34,6 +34,7 @@ model User {
   visitorEntriesLogged     VisitorEntry[]     @relation("EntryLogger")
   visitorEntriesApproved   VisitorEntry[]     @relation("EntryApprover")
   visitorPreApprovals      VisitorPreApproval[] @relation("PreApprovalApprover")
+  notifications UserNotification[] @relation("UserNotifications")
   
   @@map("users")
 }
@@ -82,6 +83,7 @@ model Organization {
   visitors            Visitor[]
   visitorEntries      VisitorEntry[]
   visitorPreApprovals VisitorPreApproval[]
+  userNotifications UserNotification[]
 
   @@map("organizations")
 }
@@ -494,6 +496,29 @@ model VisitorPreApproval {
   @@index([orgId])
   @@index([orgId, unitId])
   @@map("visitor_pre_approvals")
+}
+
+// ─────────────────────────────────────────────
+// Notification Inbox
+// ─────────────────────────────────────────────
+
+model UserNotification {
+  id        String   @id @default(uuid())
+  userId    String
+  orgId     String
+  title     String
+  body      String
+  screen    String?
+  data      Json?
+  isRead    Boolean  @default(false)
+  createdAt DateTime @default(now())
+
+  user      User         @relation("UserNotifications", fields: [userId], references: [id])
+  org       Organization @relation(fields: [orgId], references: [id])
+
+  @@index([userId, isRead])
+  @@index([userId, createdAt])
+  @@map("user_notifications")
 }
 
 enum ComplaintCategory {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -10,6 +10,7 @@ import complaintsRouter from './routes/complaints'
 import announcementsRouter from './routes/announcements'
 import unitsRouter from './routes/units'
 import visitorsRouter from './routes/visitors'
+import notificationsRouter from './routes/notifications'
 import { enforceTenantContext } from './middleware/tenantContext'
 import { errorHandler } from './middleware/error'
 import { apiRateLimit } from './middleware/rateLimit'
@@ -32,6 +33,7 @@ app.use('/api/societies', complaintsRouter)
 app.use('/api/societies', announcementsRouter)
 app.use('/api/societies', unitsRouter)
 app.use('/api/societies', visitorsRouter)
+app.use('/api', notificationsRouter)
 
 // Initialize notification dispatcher
 initNotificationDispatcher()

--- a/apps/api/src/notifications/rules.ts
+++ b/apps/api/src/notifications/rules.ts
@@ -95,7 +95,7 @@ export const notificationRules: Partial<Record<string, NotificationRule>> = {
       body: d.title,
       priority: d.category === 'EMERGENCY' ? 'high' : 'default',
       data: {
-        screen: 'Announcements',
+        screen: 'AnnouncementsList',
         orgId: d.orgId,
       }
     })

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,0 +1,121 @@
+import { Router, Response } from 'express'
+import { prisma } from '../lib/prisma'
+import { authenticate, AuthRequest } from '../middleware/auth'
+import { sendSuccess, sendError } from '../utils/response'
+
+const router = Router()
+
+// ─────────────────────────────────────────────
+// GET /api/notifications/unread-count
+// User-scoped — no society context needed
+// ─────────────────────────────────────────────
+router.get(
+  '/notifications/unread-count',
+  authenticate,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user!.userId
+
+      const count = await prisma.userNotification.count({
+        where: { userId, isRead: false }
+      })
+
+      return sendSuccess(res, { count })
+
+    } catch (error) {
+      console.error('GET /notifications/unread-count error:', error)
+      return sendError(res, 'server_error', 500)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// PATCH /api/notifications/read
+// If ids provided: mark those only (must belong to userId)
+// If no ids: mark ALL unread for this user as read
+// ─────────────────────────────────────────────
+router.patch(
+  '/notifications/read',
+  authenticate,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user!.userId
+      const { ids } = req.body
+
+      let result
+
+      if (ids && Array.isArray(ids) && ids.length > 0) {
+        result = await prisma.userNotification.updateMany({
+          where: { id: { in: ids }, userId },
+          data: { isRead: true }
+        })
+      } else {
+        result = await prisma.userNotification.updateMany({
+          where: { userId, isRead: false },
+          data: { isRead: true }
+        })
+      }
+
+      return sendSuccess(res, { updated: result.count })
+
+    } catch (error) {
+      console.error('PATCH /notifications/read error:', error)
+      return sendError(res, 'server_error', 500)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// GET /api/notifications
+// Paginated inbox — newest first
+// Query: limit (default 20, max 50), before (ISO cursor)
+// ─────────────────────────────────────────────
+router.get(
+  '/notifications',
+  authenticate,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const userId = req.user!.userId
+      const { before } = req.query
+
+      const rawLimit = parseInt(req.query.limit as string, 10)
+      const limit = isNaN(rawLimit) ? 20 : Math.min(rawLimit, 50)
+
+      const where: any = { userId }
+      if (before) {
+        where.createdAt = { lt: new Date(before as string) }
+      }
+
+      const notifications = await prisma.userNotification.findMany({
+        where,
+        orderBy: { createdAt: 'desc' },
+        take: limit + 1
+      })
+
+      const hasMore = notifications.length > limit
+      if (hasMore) notifications.pop()
+
+      return sendSuccess(res, {
+        notifications: notifications.map(n => ({
+          id: n.id,
+          title: n.title,
+          body: n.body,
+          screen: n.screen,
+          data: n.data,
+          isRead: n.isRead,
+          createdAt: n.createdAt.toISOString()
+        })),
+        hasMore,
+        nextCursor: hasMore
+          ? notifications[notifications.length - 1].createdAt.toISOString()
+          : null
+      })
+
+    } catch (error) {
+      console.error('GET /notifications error:', error)
+      return sendError(res, 'server_error', 500)
+    }
+  }
+)
+
+export default router

--- a/apps/api/src/utils/expoPush.ts
+++ b/apps/api/src/utils/expoPush.ts
@@ -75,6 +75,28 @@ export const sendPushToUsers = async (
       where: { token: { in: expiredTokens } }
     })
   }
+
+  // Persist notifications to inbox for each recipient
+  if (userIds.length > 0) {
+    const orgId = payload.data?.orgId
+    if (orgId) {
+      try {
+        await prisma.userNotification.createMany({
+          data: userIds.map(userId => ({
+            userId,
+            orgId,
+            title: payload.title,
+            body: payload.body,
+            screen: payload.data?.screen ?? null,
+            data: payload.data ?? null,
+          }))
+        })
+      } catch (error) {
+        // Never let persistence failure affect push delivery
+        console.error('Failed to persist notifications:', error)
+      }
+    }
+  }
 }
 
 // ─────────────────────────────────────────────

--- a/apps/api/tests/notifications.test.ts
+++ b/apps/api/tests/notifications.test.ts
@@ -1,0 +1,269 @@
+import request from 'supertest'
+import app from '../src/app'
+import { getTokens, getSocietyId } from './setup'
+import { prisma } from '../src/lib/prisma'
+
+describe('Notifications', () => {
+  let builderToken: string
+  let residentToken: string
+  let societyId: string
+  let residentUserId: string
+  let builderUserId: string
+  // notifIds ordered oldest → newest: [0] notif1, [1] notif2, [2] notif3
+  let notifIds: string[]
+
+  beforeAll(async () => {
+    const tokens = await getTokens()
+    builderToken  = tokens['Builder']
+    residentToken = tokens['Resident']
+    societyId     = await getSocietyId()
+
+    const resident = await prisma.user.findFirst({
+      where: { phone: '+919222222222' }
+    })
+    const builder = await prisma.user.findFirst({
+      where: { phone: '+919111111111' }
+    })
+    residentUserId = resident!.id
+    builderUserId  = builder!.id
+
+    // Explicit createdAt so ordering is deterministic across all tests
+    await prisma.userNotification.createMany({
+      data: [
+        {
+          userId: residentUserId,
+          orgId:  societyId,
+          title:  'Test Notification 1',
+          body:   'Body 1',
+          screen: 'Announcements',
+          data:   { orgId: societyId },
+          isRead: false,
+          createdAt: new Date('2026-01-01T10:00:00Z'),
+        },
+        {
+          userId: residentUserId,
+          orgId:  societyId,
+          title:  'Test Notification 2',
+          body:   'Body 2',
+          screen: 'ComplaintDetail',
+          data:   { orgId: societyId },
+          isRead: true,
+          createdAt: new Date('2026-01-02T10:00:00Z'),
+        },
+        {
+          userId: residentUserId,
+          orgId:  societyId,
+          title:  'Test Notification 3',
+          body:   'Body 3',
+          screen: 'VisitorApproval',
+          data:   { orgId: societyId },
+          isRead: false,
+          createdAt: new Date('2026-01-03T10:00:00Z'),
+        },
+      ]
+    })
+
+    const created = await prisma.userNotification.findMany({
+      where:   { userId: residentUserId },
+      orderBy: { createdAt: 'asc' }
+    })
+    notifIds = created.map(n => n.id)
+  })
+
+  afterAll(async () => {
+    await prisma.userNotification.deleteMany({ where: { userId: residentUserId } })
+    await prisma.userNotification.deleteMany({ where: { userId: builderUserId } })
+  })
+
+  // ─────────────────────────────────────────────
+  // GET /api/notifications/unread-count
+  // ─────────────────────────────────────────────
+  describe('GET /api/notifications/unread-count', () => {
+    it('returns 401 with no token', async () => {
+      const res = await request(app).get('/api/notifications/unread-count')
+      expect(res.status).toBe(401)
+    })
+
+    it('returns unread count for resident (should be 2)', async () => {
+      const res = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.count).toBe(2)
+    })
+
+    it('returns 0 for builder (no notifications created for them)', async () => {
+      const res = await request(app)
+        .get('/api/notifications/unread-count')
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.count).toBe(0)
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // GET /api/notifications
+  // ─────────────────────────────────────────────
+  describe('GET /api/notifications', () => {
+    it('returns 401 with no token', async () => {
+      const res = await request(app).get('/api/notifications')
+      expect(res.status).toBe(401)
+    })
+
+    it('returns notifications for resident newest first', async () => {
+      const res = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(res.status).toBe(200)
+      const notifs = res.body.data.notifications
+      expect(Array.isArray(notifs)).toBe(true)
+      expect(notifs.length).toBe(3)
+      // Descending order
+      for (let i = 1; i < notifs.length; i++) {
+        expect(new Date(notifs[i - 1].createdAt).getTime()).toBeGreaterThanOrEqual(
+          new Date(notifs[i].createdAt).getTime()
+        )
+      }
+      expect(notifs[0].title).toBe('Test Notification 3')
+      expect(notifs[2].title).toBe('Test Notification 1')
+    })
+
+    it('returns only resident notifications not builder notifications', async () => {
+      const builderRes = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(builderRes.status).toBe(200)
+      expect(builderRes.body.data.notifications.length).toBe(0)
+
+      const residentRes = await request(app)
+        .get('/api/notifications')
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(residentRes.status).toBe(200)
+      expect(residentRes.body.data.notifications.length).toBe(3)
+    })
+
+    it('respects limit query param', async () => {
+      const res = await request(app)
+        .get('/api/notifications?limit=1')
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.notifications.length).toBe(1)
+      // Newest first
+      expect(res.body.data.notifications[0].title).toBe('Test Notification 3')
+    })
+
+    it('returns hasMore true when more exist', async () => {
+      const res = await request(app)
+        .get('/api/notifications?limit=2')
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.notifications.length).toBe(2)
+      expect(res.body.data.hasMore).toBe(true)
+      expect(res.body.data.nextCursor).not.toBeNull()
+    })
+
+    it('returns hasMore false when all returned', async () => {
+      const res = await request(app)
+        .get('/api/notifications?limit=10')
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.notifications.length).toBe(3)
+      expect(res.body.data.hasMore).toBe(false)
+      expect(res.body.data.nextCursor).toBeNull()
+    })
+
+    it('filters by before cursor correctly', async () => {
+      // Page 1: limit=2 returns notif3, notif2 — cursor points at notif2
+      const page1 = await request(app)
+        .get('/api/notifications?limit=2')
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(page1.status).toBe(200)
+      const cursor = page1.body.data.nextCursor
+      expect(cursor).not.toBeNull()
+
+      // Page 2: before=cursor should return only notif1
+      const page2 = await request(app)
+        .get(`/api/notifications?before=${encodeURIComponent(cursor)}`)
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(page2.status).toBe(200)
+      expect(page2.body.data.notifications.length).toBe(1)
+      expect(page2.body.data.notifications[0].title).toBe('Test Notification 1')
+      expect(page2.body.data.hasMore).toBe(false)
+      expect(page2.body.data.nextCursor).toBeNull()
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // PATCH /api/notifications/read
+  // Tests run in sequence — each builds on previous state
+  // Starting state: notif1 unread, notif2 read, notif3 unread
+  // ─────────────────────────────────────────────
+  describe('PATCH /api/notifications/read', () => {
+    it('returns 401 with no token', async () => {
+      const res = await request(app).patch('/api/notifications/read').send({})
+      expect(res.status).toBe(401)
+    })
+
+    it('marks specific notifications as read when ids provided', async () => {
+      // notifIds[0] = notif1 (isRead: false)
+      const res = await request(app)
+        .patch('/api/notifications/read')
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({ ids: [notifIds[0]] })
+      expect(res.status).toBe(200)
+      expect(res.body.data.updated).toBe(1)
+
+      const notif = await prisma.userNotification.findUnique({ where: { id: notifIds[0] } })
+      expect(notif?.isRead).toBe(true)
+    })
+
+    it('marks all unread as read when no ids provided', async () => {
+      // After previous test: notif1 read, notif2 read, notif3 still unread → 1 remaining
+      const res = await request(app)
+        .patch('/api/notifications/read')
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({})
+      expect(res.status).toBe(200)
+      expect(res.body.data.updated).toBe(1)
+
+      const unreadCount = await prisma.userNotification.count({
+        where: { userId: residentUserId, isRead: false }
+      })
+      expect(unreadCount).toBe(0)
+    })
+
+    it('cannot mark another user notifications as read', async () => {
+      const builderNotif = await prisma.userNotification.create({
+        data: {
+          userId: builderUserId,
+          orgId:  societyId,
+          title:  'Builder Notification',
+          body:   'Should not be markable by resident',
+          isRead: false,
+        }
+      })
+
+      // updateMany is scoped to userId — silently updates 0 records
+      const res = await request(app)
+        .patch('/api/notifications/read')
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({ ids: [builderNotif.id] })
+      expect(res.status).toBe(200)
+      expect(res.body.data.updated).toBe(0)
+
+      const unchanged = await prisma.userNotification.findUnique({ where: { id: builderNotif.id } })
+      expect(unchanged?.isRead).toBe(false)
+    })
+
+    it('returns updated count', async () => {
+      // All resident notifications are already read — marking all unread returns 0
+      const res = await request(app)
+        .patch('/api/notifications/read')
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({})
+      expect(res.status).toBe(200)
+      expect(typeof res.body.data.updated).toBe('number')
+      expect(res.body.data.updated).toBe(0)
+    })
+  })
+})

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -23,6 +23,7 @@ import { ActiveVisitorsScreen } from '../screens/visitors/ActiveVisitorsScreen'
 import { EntryLogScreen } from '../screens/visitors/EntryLogScreen'
 import { VisitorApprovalScreen } from '../screens/visitors/VisitorApprovalScreen'
 import { MyVisitorsScreen } from '../screens/visitors/MyVisitorsScreen'
+import { NotificationsScreen } from '../screens/notifications/NotificationsScreen'
 import { Colors } from '../constants/colors'
 
 export type AppStackParamList = {
@@ -55,6 +56,7 @@ export type AppStackParamList = {
   EntryLog: { societyId: string }
   VisitorApproval: { societyId: string; entryId: string }
   MyVisitors: { societyId: string }
+  Notifications: { societyId: string }
 }
 
 const Stack = createNativeStackNavigator<AppStackParamList>()
@@ -103,6 +105,7 @@ export function AppNavigator({ initialSocietyId }: AppNavigatorProps) {
       <Stack.Screen name="EntryLog" component={EntryLogScreen} options={{ title: 'Visitor Log' }} />
       <Stack.Screen name="VisitorApproval" component={VisitorApprovalScreen} options={{ title: '', headerShown: false }} />
       <Stack.Screen name="MyVisitors" component={MyVisitorsScreen} options={{ title: 'My Visitors' }} />
+      <Stack.Screen name="Notifications" component={NotificationsScreen} options={{ title: 'Notifications' }} />
     </Stack.Navigator>
   )
 }

--- a/apps/mobile/src/screens/notifications/NotificationsScreen.tsx
+++ b/apps/mobile/src/screens/notifications/NotificationsScreen.tsx
@@ -1,0 +1,348 @@
+import React, { useState, useCallback, useEffect } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  RefreshControl,
+  Pressable,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { useFocusEffect } from '@react-navigation/native'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { LoadingSpinner } from '../../components/LoadingSpinner'
+import { Toast } from '../../components/Toast'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import {
+  InboxNotification,
+  getNotifications,
+  markNotificationsRead,
+} from '../../services/notificationInbox'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+import { Ionicons } from '@expo/vector-icons'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'Notifications'>
+
+// ─── Icon config per notification screen type ─────────────────────────────────
+
+const SCREEN_CONFIG: Record<string, { icon: keyof typeof Ionicons.glyphMap; color: string; bg: string }> = {
+  VisitorApproval:   { icon: 'person-outline',    color: '#3b82f6', bg: '#eff6ff' },
+  ActiveVisitors:    { icon: 'person-outline',    color: '#3b82f6', bg: '#eff6ff' },
+  AnnouncementsList: { icon: 'megaphone-outline', color: '#9333ea', bg: '#faf5ff' },
+  ComplaintDetail:   { icon: 'warning-outline',   color: '#f97316', bg: '#fff7ed' },
+}
+const DEFAULT_CONFIG = { icon: 'notifications-outline' as const, color: '#6b7280', bg: '#f3f4f6' }
+
+// ─── Navigate based on notification screen field ──────────────────────────────
+
+function navigateToScreen(
+  item: InboxNotification,
+  navigation: Props['navigation'],
+  societyId: string,
+) {
+  const orgId = item.data?.orgId ?? societyId
+  switch (item.screen) {
+    case 'VisitorApproval':
+      if (item.data?.entryId) {
+        navigation.navigate('VisitorApproval', { societyId: orgId, entryId: item.data.entryId })
+      }
+      break
+    case 'ActiveVisitors':
+      navigation.navigate('ActiveVisitors', { societyId: orgId })
+      break
+    case 'AnnouncementsList':
+      navigation.navigate('AnnouncementsList', { societyId: orgId })
+      break
+    case 'ComplaintDetail':
+      if (item.data?.complaintId) {
+        navigation.navigate('ComplaintDetail', {
+          societyId: orgId,
+          complaintId: item.data.complaintId,
+          title: item.title,
+        })
+      }
+      break
+    default:
+      break
+  }
+}
+
+// ─── Main Screen ──────────────────────────────────────────────────────────────
+
+export function NotificationsScreen({ route, navigation }: Props) {
+  const { societyId } = route.params
+
+  const [notifications, setNotifications] = useState<InboxNotification[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+
+  const hasUnread = notifications.some(n => !n.isRead)
+
+  // ─── Load first page ───────────────────────────────────────────────────────
+
+  const loadInitial = useCallback(async (refreshing = false) => {
+    try {
+      if (!refreshing) setIsLoading(true)
+      else setIsRefreshing(true)
+      const result = await getNotifications()
+      setNotifications(result.notifications)
+      setHasMore(result.hasMore)
+      setNextCursor(result.nextCursor)
+    } catch {
+      setToast({ message: 'Could not load notifications. Pull to retry.', type: 'error' })
+    } finally {
+      setIsLoading(false)
+      setIsRefreshing(false)
+    }
+  }, [])
+
+  useFocusEffect(
+    useCallback(() => {
+      loadInitial()
+    }, [loadInitial]),
+  )
+
+  const onRefresh = useCallback(() => {
+    loadInitial(true)
+  }, [loadInitial])
+
+  // ─── Load next page ────────────────────────────────────────────────────────
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || isLoadingMore || !nextCursor) return
+    setIsLoadingMore(true)
+    try {
+      const result = await getNotifications(nextCursor)
+      setNotifications(prev => [...prev, ...result.notifications])
+      setHasMore(result.hasMore)
+      setNextCursor(result.nextCursor)
+    } catch {
+      // fail silently on pagination
+    } finally {
+      setIsLoadingMore(false)
+    }
+  }, [hasMore, isLoadingMore, nextCursor])
+
+  // ─── Auto-mark all read after 3s ──────────────────────────────────────────
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      markNotificationsRead()
+        .then(() => {
+          setNotifications(prev => prev.map(n => ({ ...n, isRead: true })))
+        })
+        .catch(() => {})
+    }, 3000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  // ─── Mark all read button ─────────────────────────────────────────────────
+
+  const handleMarkAllRead = useCallback(async () => {
+    try {
+      await markNotificationsRead()
+      setNotifications(prev => prev.map(n => ({ ...n, isRead: true })))
+    } catch {
+      setToast({ message: 'Failed to mark as read.', type: 'error' })
+    }
+  }, [])
+
+  useEffect(() => {
+    navigation.setOptions({
+      headerRight: hasUnread ? () => (
+        <TouchableOpacity onPress={handleMarkAllRead} hitSlop={12} style={styles.markAllBtn}>
+          <Text style={styles.markAllText}>Mark all read</Text>
+        </TouchableOpacity>
+      ) : undefined,
+    })
+  }, [notifications, handleMarkAllRead, navigation])
+
+  // ─── Tap handler ──────────────────────────────────────────────────────────
+
+  const handleTap = useCallback((item: InboxNotification) => {
+    setNotifications(prev =>
+      prev.map(n => n.id === item.id ? { ...n, isRead: true } : n)
+    )
+    markNotificationsRead([item.id]).catch(() => {})
+    navigateToScreen(item, navigation, societyId)
+  }, [navigation, societyId])
+
+  // ─── Render ───────────────────────────────────────────────────────────────
+
+  const renderItem = ({ item }: { item: InboxNotification }) => {
+    const config = SCREEN_CONFIG[item.screen ?? ''] ?? DEFAULT_CONFIG
+    return (
+      <Pressable
+        onPress={() => handleTap(item)}
+        style={({ pressed }) => [
+          styles.row,
+          !item.isRead && styles.rowUnread,
+          pressed && styles.rowPressed,
+        ]}
+      >
+        <View style={[styles.rowIcon, { backgroundColor: config.bg }]}>
+          <Ionicons name={config.icon} size={20} color={config.color} />
+        </View>
+        <View style={styles.rowContent}>
+          <Text
+            style={[styles.rowTitle, !item.isRead && styles.rowTitleUnread]}
+            numberOfLines={1}
+          >
+            {item.title}
+          </Text>
+          <Text style={styles.rowBody} numberOfLines={2}>
+            {item.body}
+          </Text>
+          <Text style={styles.rowTime}>{timeAgo(item.createdAt)}</Text>
+        </View>
+        {!item.isRead && <View style={styles.unreadDot} />}
+      </Pressable>
+    )
+  }
+
+  if (isLoading) return <LoadingSpinner fullScreen />
+
+  return (
+    <ScreenWrapper scroll={false} style={styles.wrapper}>
+      <FlatList
+        data={notifications}
+        keyExtractor={item => item.id}
+        renderItem={renderItem}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={onRefresh}
+            tintColor={Colors.primary}
+            colors={[Colors.primary]}
+          />
+        }
+        onEndReached={loadMore}
+        onEndReachedThreshold={0.2}
+        ListFooterComponent={isLoadingMore ? (
+          <View style={styles.footerLoader}>
+            <ActivityIndicator size="small" color={Colors.primary} />
+          </View>
+        ) : null}
+        ListEmptyComponent={
+          <View style={styles.emptyFull}>
+            <Ionicons name="notifications-outline" size={48} color={Colors.border} />
+            <Text style={styles.emptyTitle}>No notifications yet</Text>
+          </View>
+        }
+        contentContainerStyle={notifications.length === 0 ? styles.emptyContainer : undefined}
+      />
+
+      {toast ? (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          visible={!!toast}
+          onHide={() => setToast(null)}
+        />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return new Date(iso).toLocaleDateString('en-IN', { day: 'numeric', month: 'short' })
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  wrapper: { backgroundColor: Colors.background },
+
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 14,
+    backgroundColor: Colors.surface,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    gap: 12,
+    minHeight: Spacing.minTapTarget,
+  },
+  rowUnread: { backgroundColor: '#f8faff' },
+  rowPressed: { backgroundColor: Colors.background },
+
+  rowIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  rowContent: { flex: 1, gap: 3 },
+  rowTitle: {
+    fontSize: 15,
+    fontWeight: '500',
+    color: Colors.text,
+  },
+  rowTitleUnread: { fontWeight: '700' },
+  rowBody: {
+    fontSize: 13,
+    color: Colors.subtle,
+    lineHeight: 18,
+  },
+  rowTime: {
+    fontSize: 12,
+    color: Colors.subtle,
+  },
+
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.primary,
+    flexShrink: 0,
+  },
+
+  emptyContainer: { flexGrow: 1 },
+  emptyFull: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 12,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: Colors.subtle,
+  },
+
+  footerLoader: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+
+  markAllBtn: {
+    marginRight: 4,
+    padding: 4,
+  },
+  markAllText: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.primary,
+  },
+})

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useCallback, useState } from 'react'
+import { useFocusEffect } from '@react-navigation/native'
 import {
   View,
   Text,
@@ -23,6 +24,7 @@ import { updateProfile } from '../../services/auth'
 import { getApiErrorCode } from '../../services/api'
 import { getErrorMessage } from '../../utils/errorMessages'
 import { VisitorEntry, getActiveVisitors, getEntryLog } from '../../services/visitors'
+import { getUnreadCount } from '../../services/notificationInbox'
 import { Colors } from '../../constants/colors'
 import { Spacing } from '../../constants/spacing'
 import { Ionicons } from '@expo/vector-icons'
@@ -114,6 +116,7 @@ export function DashboardScreen({ route, navigation }: Props) {
   const [todayCount, setTodayCount] = useState(0)
   const [pendingCount, setPendingCount] = useState(0)
   const [pendingEntry, setPendingEntry] = useState<VisitorEntry | null>(null)
+  const [unreadCount, setUnreadCount] = useState(0)
 
   function openProfile() {
     setProfileName(user?.name ?? '')
@@ -145,6 +148,21 @@ export function DashboardScreen({ route, navigation }: Props) {
     }
   }
 
+  const loadNotificationBadge = useCallback(async () => {
+    try {
+      const result = await getUnreadCount()
+      setUnreadCount(result.count)
+    } catch {
+      // non-critical
+    }
+  }, [])
+
+  useFocusEffect(
+    useCallback(() => {
+      loadNotificationBadge()
+    }, [loadNotificationBadge]),
+  )
+
   const loadVisitorStats = useCallback(async () => {
     if (permissions.includes('visitor.log')) {
       const active = await getActiveVisitors(societyId)
@@ -172,8 +190,8 @@ export function DashboardScreen({ route, navigation }: Props) {
   }, [load, loadVisitorStats])
 
   const onRefresh = useCallback(async () => {
-    await Promise.all([load(), loadUser(), loadVisitorStats()])
-  }, [load, loadUser, loadVisitorStats])
+    await Promise.all([load(), loadUser(), loadVisitorStats(), loadNotificationBadge()])
+  }, [load, loadUser, loadVisitorStats, loadNotificationBadge])
 
   const canCreateSociety = permissions.includes('society.create')
 
@@ -192,21 +210,40 @@ export function DashboardScreen({ route, navigation }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.name, navigation])
 
-  // "+" to create another society — builders only
+  // Bell icon (all roles) + "+" button (builders only)
   useEffect(() => {
-    if (!canCreateSociety) return
     navigation.setOptions({
       headerRight: () => (
-        <TouchableOpacity
-          onPress={() => navigation.navigate('CreateSociety', { source: 'dashboard' })}
-          hitSlop={12}
-          style={styles.headerButton}
-        >
-          <Text style={styles.headerButtonText}>+</Text>
-        </TouchableOpacity>
+        <View style={styles.headerRightRow}>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('Notifications', { societyId })}
+            style={styles.headerButton}
+            hitSlop={12}
+          >
+            <View>
+              <Ionicons name="notifications-outline" size={24} color={Colors.primary} />
+              {unreadCount > 0 && (
+                <View style={styles.badgeContainer}>
+                  <Text style={styles.badgeText}>
+                    {unreadCount > 99 ? '99+' : unreadCount}
+                  </Text>
+                </View>
+              )}
+            </View>
+          </TouchableOpacity>
+          {canCreateSociety && (
+            <TouchableOpacity
+              onPress={() => navigation.navigate('CreateSociety', { source: 'dashboard' })}
+              hitSlop={12}
+              style={styles.headerButton}
+            >
+              <Text style={styles.headerButtonText}>+</Text>
+            </TouchableOpacity>
+          )}
+        </View>
       ),
     })
-  }, [canCreateSociety, navigation])
+  }, [canCreateSociety, unreadCount, navigation, societyId])
 
   // Permission gates — as per MOBILE_CONTEXT.md
   const canViewStructure = permissions.includes('node.view')
@@ -812,8 +849,13 @@ const styles = StyleSheet.create({
   },
 
   // Header
-  headerButton: {
+  headerRightRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
     marginRight: 4,
+  },
+  headerButton: {
     padding: 4,
   },
   headerButtonText: {
@@ -821,6 +863,24 @@ const styles = StyleSheet.create({
     color: Colors.primary,
     fontWeight: '400',
     lineHeight: 30,
+  },
+
+  badgeContainer: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    backgroundColor: Colors.error,
+    borderRadius: 8,
+    minWidth: 16,
+    height: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 3,
+  },
+  badgeText: {
+    color: 'white',
+    fontSize: 10,
+    fontWeight: '700',
   },
 
   // Header avatar (profile button)

--- a/apps/mobile/src/services/notificationInbox.ts
+++ b/apps/mobile/src/services/notificationInbox.ts
@@ -1,0 +1,33 @@
+import api from './api'
+
+export interface InboxNotification {
+  id: string
+  title: string
+  body: string
+  screen?: string
+  data?: Record<string, string>
+  isRead: boolean
+  createdAt: string
+}
+
+export async function getNotifications(before?: string): Promise<{
+  notifications: InboxNotification[]
+  hasMore: boolean
+  nextCursor: string | null
+}> {
+  const params: Record<string, string | number> = { limit: 20 }
+  if (before) params.before = before
+  const res = await api.get('/notifications', { params })
+  return res.data.data
+}
+
+export async function markNotificationsRead(ids?: string[]): Promise<{ updated: number }> {
+  const body = ids && ids.length > 0 ? { ids } : {}
+  const res = await api.patch('/notifications/read', body)
+  return res.data.data
+}
+
+export async function getUnreadCount(): Promise<{ count: number }> {
+  const res = await api.get('/notifications/unread-count')
+  return res.data.data
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -465,14 +465,29 @@ Token reassigned to new userId when user switches accounts on same device — ex
   notifiedAt only set when at least one push notification actually sent.
 
 ## Decision 043 — Duplicate visitor entries allowed in V1
-**Date:** 9 May 2026
+**Date:** 18 May 2026
   No prevention if same visitor is logged twice while already inside.
   Gatekeeper is responsible for checking Active Visitors screen first.
   V2: add warning when visitor already has an active (entered, not exited) entry.
 
 ## Decision 044 — Actionable push notifications deferred to V2
-**Date:** 9 May 2026
+**Date:** 18 May 2026
   Residents must open the app to approve or deny.
   Complexity of headless background task execution not justified for V1 scale.
   In-app fallback: MyVisitors Recent tab surfaces all pending entries
   so missed notifications don't block visitors indefinitely.
+
+## Decision 045 — Notification persistence via expoPush.ts
+Date: 19 May 2026
+UserNotification records written inside expoPush.ts
+after each push is sent. This means all notification
+types are automatically persisted without changing
+individual route files or event rules.
+Single responsibility: expoPush handles both delivery
+and persistence.
+
+## Decision 046 — Cursor-based pagination for inbox
+Date: 19 May 2026
+20 items per page using createdAt as cursor.
+No time limit on history — complete record kept in DB.
+UI loads lazily via infinite scroll.

--- a/docs/briefs/notification-inbox.md
+++ b/docs/briefs/notification-inbox.md
@@ -1,0 +1,38 @@
+# Notification Inbox — Feature Brief
+
+## Overview
+Every push notification sent to a user is also stored
+in the database. Users can view full notification history
+in an inbox screen accessible from the dashboard.
+
+## Who Sees It
+All roles — every user has a notification inbox.
+
+## What Goes In Inbox
+All 8 current notification types:
+  COMPLAINT_CREATED, COMPLAINT_RESOLVED, COMPLAINT_REJECTED
+  ANNOUNCEMENT_CREATED
+  VISITOR_AT_GATE, VISITOR_APPROVED, VISITOR_DENIED
+  VISITOR_PRE_APPROVAL_USED
+
+## Pagination
+20 notifications per page.
+Cursor-based (before= param using createdAt).
+No time limit — complete history preserved in DB.
+
+## Mark As Read
+Tap notification → marks that one read + navigates.
+3 seconds in inbox → marks all visible as read.
+Bell badge shows total unread count.
+
+## Badge Location
+Bell icon in dashboard header (tab bar in V2).
+
+## Endpoints
+GET  /notifications               paginated list
+PATCH /notifications/read         mark read (one or all)
+GET  /notifications/unread-count  badge count
+
+## Implementation Note
+Notifications written to DB inside expoPush.ts
+after push is sent. Single change covers all types.


### PR DESCRIPTION
### Backend
- UserNotification schema and migration
- Every push notification automatically persisted to DB
  via single change in expoPush.ts
- 3 endpoints: paginated list, mark read, unread count
- Cursor-based pagination (20 per page, no time limit)
- 15 new tests, 279 total passing

### Mobile
- NotificationsScreen: paginated inbox with infinite scroll
- Unread dot on each unread notification
- Tap notification → marks read + navigates to relevant screen
- 3 second auto-mark-all-read when inbox opens
- Pull to refresh
- Bell icon in dashboard header for all roles
- Unread count badge on bell (red, shows 99+ when overflow)
- Badge refreshes via useFocusEffect on dashboard return
- Builder keeps + button alongside bell in header

### Bug fixes
- Announcement notification screen name corrected
  (Announcements → AnnouncementsList in rules.ts)