### PR TITLE
feat: direct add member + member UX improvements

### DIFF
--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -5,10 +5,12 @@ import { enforceTenantContext } from '../middleware/tenantContext'
 import { prisma } from '../lib/prisma'
 import {
   sendSuccess,
+  sendCreated,
   sendError,
   sendNotFound,
   sendServerError
 } from '../utils/response'
+import { validatePhone, normalizePhone } from '../utils/validate'
 
 const router = Router()
 
@@ -219,6 +221,213 @@ router.get(
 
     } catch (error) {
       console.error('GET /societies/:id/members/:memberId error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// POST /api/societies/:id/members/direct-add
+// Admin/Builder directly adds a member without SMS invite
+// Creates User + Person if phone not in system
+// Optionally assigns unit occupancy in same transaction
+// ─────────────────────────────────────────────
+router.post(
+  '/:id/members/direct-add',
+  authenticate,
+  enforceTenantContext,
+  requirePermission('member.remove'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const orgId = req.params.id as string
+      const { name, phone, role, unitId, occupancyType } = req.body
+
+      // 1. Validate required fields
+      if (!name || typeof name !== 'string' || name.trim().length < 2) {
+        return sendError(res, 'invalid_name', 400, {
+          message: 'Name must be at least 2 characters'
+        })
+      }
+      if (!phone || typeof phone !== 'string') {
+        return sendError(res, 'invalid_phone', 400, {
+          message: 'Phone number is required'
+        })
+      }
+      if (!role || typeof role !== 'string') {
+        return sendError(res, 'invalid_role', 400, {
+          message: 'Role is required'
+        })
+      }
+
+      // 2. Normalize and validate phone
+      const normalizedPhone = normalizePhone(phone)
+      const phoneValidation = validatePhone(normalizedPhone)
+      if (!phoneValidation.valid) {
+        return sendError(res, 'invalid_phone', 400, {
+          message: 'Invalid phone number format'
+        })
+      }
+
+      // 3. Role permission check
+      const callerMembership = await prisma.membership.findFirst({
+        where: { userId: req.user!.userId, orgId, isActive: true },
+        include: { role: true }
+      })
+      const callerRole = callerMembership?.role.name
+      const allowedRolesForAdmin = ['Resident', 'Co-resident', 'Gatekeeper']
+      const allowedRolesForBuilder = ['Admin', 'Resident', 'Co-resident', 'Gatekeeper']
+
+      if (callerRole === 'Admin' && !allowedRolesForAdmin.includes(role)) {
+        return sendError(res, 'role_not_allowed', 403, {
+          message: 'Admin can only add Resident, Co-resident, or Gatekeeper'
+        })
+      }
+      if (callerRole === 'Builder' && !allowedRolesForBuilder.includes(role)) {
+        return sendError(res, 'role_not_allowed', 403, {
+          message: 'Invalid role'
+        })
+      }
+
+      // 4. Find role record (system roles have orgId: null)
+      const roleRecord = await prisma.role.findFirst({
+        where: { name: role }
+      })
+      if (!roleRecord) {
+        return sendError(res, 'invalid_role', 400, {
+          message: 'Role not found'
+        })
+      }
+
+      // 5. Check if user with this phone already exists
+      const existingUser = await prisma.user.findUnique({
+        where: { phone: normalizedPhone },
+        include: {
+          memberships: {
+            where: { orgId },
+            include: { role: true }
+          },
+          person: true
+        }
+      })
+
+      if (existingUser) {
+        const existingMembership = existingUser.memberships[0]
+        if (existingMembership) {
+          if (existingMembership.isActive) {
+            return sendError(res, 'already_member', 409, {
+              message: 'This person is already an active member'
+            })
+          } else {
+            return sendError(res, 'inactive_member', 409, {
+              message: 'This person was previously a member',
+              memberId: existingMembership.id
+            })
+          }
+        }
+      }
+
+      // 6. Validate unit if provided
+      if (unitId) {
+        if (!occupancyType) {
+          return sendError(res, 'missing_field', 400, {
+            message: 'Occupancy type required when unit is selected'
+          })
+        }
+        const unit = await prisma.propertyNode.findFirst({
+          where: { id: unitId as string, orgId, nodeType: { in: ['UNIT', 'VILLA', 'FLOOR', 'PLOT'] } }
+        })
+        if (!unit) {
+          return sendError(res, 'unit_not_found', 404, {
+            message: 'Unit not found'
+          })
+        }
+      }
+
+      // 7. All in one transaction
+      const result = await prisma.$transaction(async (tx) => {
+        let userId: string
+        let personId: string
+
+        if (existingUser) {
+          userId = existingUser.id
+          personId = existingUser.person!.id
+          await tx.person.update({
+            where: { id: personId },
+            data: { fullName: name.trim() }
+          })
+        } else {
+          const newUser = await tx.user.create({
+            data: {
+              phone: normalizedPhone,
+              tokenVersion: 0,
+              person: {
+                create: {
+                  fullName: name.trim(),
+                  phone: normalizedPhone,
+                }
+              }
+            },
+            include: { person: true }
+          })
+          userId = newUser.id
+          personId = newUser.person!.id
+        }
+
+        const membership = await tx.membership.create({
+          data: {
+            userId,
+            orgId,
+            roleId: roleRecord.id,
+            isActive: true,
+            invitedBy: req.user!.userId,
+          }
+        })
+
+        if (unitId && occupancyType) {
+          const existingPrimary = await tx.unitOccupancy.findFirst({
+            where: {
+              unitId: unitId as string,
+              isPrimary: true,
+              occupiedUntil: null
+            }
+          })
+          await tx.unitOccupancy.create({
+            data: {
+              unitId: unitId as string,
+              personId,
+              occupancyType: occupancyType as any,
+              isPrimary: !existingPrimary,
+              occupiedFrom: new Date(),
+            }
+          })
+        }
+
+        await tx.auditLog.create({
+          data: {
+            orgId,
+            tableName: 'memberships',
+            recordId: membership.id,
+            action: 'direct_add',
+            actorId: req.user!.userId,
+            newData: {
+              addedPhone: normalizedPhone,
+              addedName: name.trim(),
+              role,
+              unitId: unitId ?? null
+            }
+          }
+        })
+
+        return membership
+      })
+
+      return sendCreated(res, {
+        memberId: result.id,
+        message: 'Member added successfully'
+      })
+
+    } catch (error) {
+      console.error('direct-add error:', error)
       return sendServerError(res)
     }
   }

--- a/apps/api/tests/members.test.ts
+++ b/apps/api/tests/members.test.ts
@@ -1,6 +1,8 @@
 import request from 'supertest'
 import app from '../src/app'
 import { getTokens, getSocietyId, getMembershipId } from './setup'
+import { prisma } from '../src/lib/prisma'
+import { generateToken } from '../src/utils/jwt'
 
 describe('Members', () => {
   let builderToken: string
@@ -202,4 +204,212 @@ describe('Members', () => {
     expect(res.body.data.warning).toBeDefined()
   })
 })
+
+  // ─────────────────────────────────────────────
+  // POST /societies/:id/members/direct-add
+  // ─────────────────────────────────────────────
+  describe('POST /societies/:id/members/direct-add', () => {
+    let adminToken: string
+    let adminUserId: string
+    let unitId: string
+    const phoneA = '+919800000001'
+    const phoneB = '+919800000002'
+    const phoneC = '+919800000003'
+    let membershipIdA: string
+
+    beforeAll(async () => {
+      // Create an admin user with membership for role restriction tests
+      const adminUser = await prisma.user.create({
+        data: {
+          phone: '+919800000099',
+          phoneVerified: true,
+          tokenVersion: 0,
+          person: { create: { fullName: 'Test Admin User', phone: '+919800000099' } }
+        }
+      })
+      adminUserId = adminUser.id
+      await prisma.membership.create({
+        data: { userId: adminUser.id, orgId: societyId, roleId: 'role-admin', isActive: true }
+      })
+      adminToken = generateToken({ userId: adminUser.id, orgId: societyId, tokenVersion: 0 })
+
+      // Get a valid unit ID for unit assignment tests
+      const unit = await prisma.propertyNode.findFirst({
+        where: { orgId: societyId, nodeType: 'UNIT' }
+      })
+      unitId = unit!.id
+    })
+
+    afterAll(async () => {
+      // Remove direct_add audit logs, then users created by these tests
+      await prisma.auditLog.deleteMany({ where: { orgId: societyId, action: 'direct_add' } })
+      for (const phone of [phoneA, phoneB, phoneC, '+919800000099']) {
+        const user = await prisma.user.findUnique({ where: { phone } })
+        if (!user) continue
+        await prisma.auditLog.deleteMany({ where: { orgId: societyId, actorId: user.id } })
+        await prisma.unitOccupancy.deleteMany({ where: { person: { userId: user.id } } })
+        await prisma.membership.deleteMany({ where: { userId: user.id } })
+        const person = await prisma.person.findFirst({ where: { userId: user.id } })
+        if (person) await prisma.person.delete({ where: { id: person.id } })
+        await prisma.user.delete({ where: { id: user.id } })
+      }
+    })
+
+    it('returns 401 with no token', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .send({ name: 'Test', phone: '9800000001', role: 'Resident' })
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 403 if caller lacks member.remove permission', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({ name: 'Test', phone: '9800000001', role: 'Resident' })
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 400 if name missing', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ phone: '9800000001', role: 'Resident' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('invalid_name')
+    })
+
+    it('returns 400 if name too short', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ name: 'A', phone: '9800000001', role: 'Resident' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('invalid_name')
+    })
+
+    it('returns 400 if phone missing', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ name: 'Test User', role: 'Resident' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('invalid_phone')
+    })
+
+    it('returns 400 if invalid phone format', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ name: 'Test User', phone: '1234', role: 'Resident' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('invalid_phone')
+    })
+
+    it('returns 400 if role missing', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ name: 'Test User', phone: '9800000001' })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('invalid_role')
+    })
+
+    it('returns 403 if Admin tries to add Admin role', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'Test User', phone: '9800000001', role: 'Admin' })
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('role_not_allowed')
+    })
+
+    it('returns 403 if Admin tries to add Builder role', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'Test User', phone: '9800000001', role: 'Builder' })
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('role_not_allowed')
+    })
+
+    it('successfully adds a new member (Builder caller)', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ name: 'Direct Add Test', phone: '9800000001', role: 'Gatekeeper' })
+      expect(res.status).toBe(201)
+      expect(res.body.data.memberId).toBeDefined()
+      expect(res.body.data.message).toBe('Member added successfully')
+      membershipIdA = res.body.data.memberId
+
+      // Verify member appears in list
+      const list = await request(app)
+        .get(`/api/societies/${societyId}/members`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      const found = list.body.data.active.some((m: any) => m.membershipId === membershipIdA)
+      expect(found).toBe(true)
+    })
+
+    it('successfully adds a new member (Admin caller, Resident role)', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'Admin Added Resident', phone: '9800000002', role: 'Resident' })
+      expect(res.status).toBe(201)
+      expect(res.body.data.memberId).toBeDefined()
+    })
+
+    it('returns 409 already_member for active member', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ name: 'Direct Add Test', phone: '9800000001', role: 'Gatekeeper' })
+      expect(res.status).toBe(409)
+      expect(res.body.error).toBe('already_member')
+    })
+
+    it('returns 409 inactive_member with memberId for deactivated member', async () => {
+      // Deactivate the member added in the Builder test
+      await request(app)
+        .patch(`/api/societies/${societyId}/members/${membershipIdA}/deactivate`)
+        .set('Authorization', `Bearer ${builderToken}`)
+
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ name: 'Direct Add Test', phone: '9800000001', role: 'Gatekeeper' })
+      expect(res.status).toBe(409)
+      expect(res.body.error).toBe('inactive_member')
+      expect(res.body.details.memberId).toBe(membershipIdA)
+    })
+
+    it('returns 400 if unitId provided without occupancyType', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ name: 'Unit Test', phone: '9800000003', role: 'Resident', unitId })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('missing_field')
+    })
+
+    it('successfully adds member with unit assignment', async () => {
+      const res = await request(app)
+        .post(`/api/societies/${societyId}/members/direct-add`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ name: 'Unit Test Resident', phone: '9800000003', role: 'Resident', unitId, occupancyType: 'TENANT' })
+      expect(res.status).toBe(201)
+      expect(res.body.data.memberId).toBeDefined()
+
+      // Verify occupancy was created
+      const user = await prisma.user.findUnique({ where: { phone: phoneC } })
+      const person = await prisma.person.findFirst({ where: { userId: user!.id } })
+      const occupancy = await prisma.unitOccupancy.findFirst({
+        where: { personId: person!.id, occupiedUntil: null }
+      })
+      expect(occupancy).not.toBeNull()
+      expect(occupancy!.occupancyType).toBe('TENANT')
+      expect(occupancy!.unitId).toBe(unitId)
+    })
+  })
 })

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -7,6 +7,7 @@ import { AddNodeScreen } from '../screens/society/AddNodeScreen'
 import { InviteMemberScreen } from '../screens/society/InviteMemberScreen'
 import { MemberListScreen } from '../screens/members/MemberListScreen'
 import { MemberDetailScreen } from '../screens/members/MemberDetailScreen'
+import { DirectAddMemberScreen } from '../screens/members/DirectAddMemberScreen'
 import { SwitchSocietyScreen } from '../screens/society/SwitchSocietyScreen'
 import { ComplaintListScreen } from '../screens/complaints/ComplaintListScreen'
 import { RaiseComplaintScreen } from '../screens/complaints/RaiseComplaintScreen'
@@ -35,6 +36,7 @@ export type AppStackParamList = {
   InviteMember: { societyId: string }
   MemberList: { societyId: string }
   MemberDetail: { societyId: string; memberId: string; memberName: string }
+  DirectAddMember: { societyId: string }
   ComplaintList: { societyId: string }
   RaiseComplaint: { societyId: string }
   ComplaintDetail: { societyId: string; complaintId: string; title: string }
@@ -89,6 +91,7 @@ export function AppNavigator({ initialSocietyId }: AppNavigatorProps) {
       <Stack.Screen name="InviteMember" component={InviteMemberScreen} options={{ title: 'Invite Member' }} />
       <Stack.Screen name="MemberList" component={MemberListScreen} options={{ title: 'Members' }} />
       <Stack.Screen name="MemberDetail" component={MemberDetailScreen} options={({ route }) => ({ title: route.params.memberName })} />
+      <Stack.Screen name="DirectAddMember" component={DirectAddMemberScreen} options={{ title: 'Add Member' }} />
       <Stack.Screen name="SwitchSociety" component={SwitchSocietyScreen} options={{ title: 'Switch Society' }} />
       <Stack.Screen name="ComplaintList" component={ComplaintListScreen} options={{ title: 'Complaints' }} />
       <Stack.Screen name="RaiseComplaint" component={RaiseComplaintScreen} options={{ title: 'Raise Complaint' }} />

--- a/apps/mobile/src/screens/members/DirectAddMemberScreen.tsx
+++ b/apps/mobile/src/screens/members/DirectAddMemberScreen.tsx
@@ -1,0 +1,443 @@
+import React, { useState, useEffect, useCallback } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  Pressable,
+  StyleSheet,
+} from 'react-native'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { TextInput } from '../../components/TextInput'
+import { Button } from '../../components/Button'
+import { BottomSheetPicker, PickerOption } from '../../components/BottomSheetPicker'
+import { ConfirmSheet } from '../../components/ConfirmSheet'
+import { Toast } from '../../components/Toast'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
+import { directAddMember, reactivateMember } from '../../services/members'
+import { listUnits, UnitListItem } from '../../services/units'
+import { getApiErrorCode, getApiErrorDetails } from '../../services/api'
+import { getErrorMessage } from '../../utils/errorMessages'
+import { formatPhoneDisplay, normalizePhone, isValidIndianPhone } from '../../utils/validators'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'DirectAddMember'>
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const ROLE_OPTIONS_BUILDER: PickerOption[] = [
+  { label: 'Admin',       value: 'Admin' },
+  { label: 'Resident',    value: 'Resident' },
+  { label: 'Co-resident', value: 'Co-resident' },
+  { label: 'Gatekeeper',  value: 'Gatekeeper' },
+]
+
+const ROLE_OPTIONS_ADMIN: PickerOption[] = [
+  { label: 'Resident',    value: 'Resident' },
+  { label: 'Co-resident', value: 'Co-resident' },
+  { label: 'Gatekeeper',  value: 'Gatekeeper' },
+]
+
+const OCCUPANCY_TYPE_OPTIONS: PickerOption[] = [
+  { label: 'Owner Resident', value: 'OWNER_RESIDENT' },
+  { label: 'Tenant',         value: 'TENANT' },
+  { label: 'Family Member',  value: 'FAMILY' },
+  { label: 'Caretaker',      value: 'CARETAKER' },
+]
+
+// ─── Screen ───────────────────────────────────────────────────────────────────
+
+export function DirectAddMemberScreen({ route, navigation }: Props) {
+  const { societyId } = route.params
+  const { memberships, permissions } = useAuth()
+
+  const currentMembership = memberships.find((m) => m.org.id === societyId)
+  const callerRole = currentMembership?.role ?? null
+  const isBuilder = callerRole === 'Builder'
+  const roleOptions = isBuilder ? ROLE_OPTIONS_BUILDER : ROLE_OPTIONS_ADMIN
+
+  // ── Form state ──
+  const [phone, setPhone] = useState('')
+  const [name, setName] = useState('')
+  const [selectedRole, setSelectedRole] = useState<string | null>(null)
+  const [selectedUnitId, setSelectedUnitId] = useState<string | null>(null)
+  const [selectedOccupancyType, setSelectedOccupancyType] = useState<string | null>(null)
+
+  // ── Picker visibility ──
+  const [showRolePicker, setShowRolePicker] = useState(false)
+  const [showUnitPicker, setShowUnitPicker] = useState(false)
+  const [showOccupancyPicker, setShowOccupancyPicker] = useState(false)
+
+  // ── Units ──
+  const [units, setUnits] = useState<UnitListItem[]>([])
+  const [unitsLoading, setUnitsLoading] = useState(true)
+
+  // ── Submission ──
+  const [isSaving, setIsSaving] = useState(false)
+
+  // ── Reactivation sheet ──
+  const [showReactivateSheet, setShowReactivateSheet] = useState(false)
+  const [inactiveMemberId, setInactiveMemberId] = useState<string | null>(null)
+  const [reactivateLoading, setReactivateLoading] = useState(false)
+
+  // ── Field errors ──
+  const [phoneError, setPhoneError] = useState('')
+  const [nameError, setNameError] = useState('')
+  const [roleError, setRoleError] = useState('')
+  const [occupancyError, setOccupancyError] = useState('')
+
+  // ── Toast ──
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+
+  // ── Load units on mount ───────────────────────────────────────────────────
+
+  useEffect(() => {
+    listUnits(societyId)
+      .then((data) => setUnits(data.units))
+      .catch(() => {}) // non-blocking — unit picker just stays empty
+      .finally(() => setUnitsLoading(false))
+  }, [societyId])
+
+  // ── Unit picker options ───────────────────────────────────────────────────
+
+  const unitPickerOptions: PickerOption[] = [
+    { label: 'No unit assigned', value: '' },
+    ...units.map((u) => ({
+      label: `${u.name}${u.primaryOccupant ? ' (Occupied)' : ' (Vacant)'}`,
+      value: u.id,
+    })),
+  ]
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
+
+  function handlePhoneChange(text: string) {
+    setPhone(formatPhoneDisplay(text))
+    setPhoneError('')
+  }
+
+  function handleUnitSelect(value: string) {
+    setSelectedUnitId(value || null)
+    setSelectedOccupancyType(null)
+    setOccupancyError('')
+  }
+
+  async function handleSubmit() {
+    let valid = true
+
+    const rawPhone = normalizePhone(phone)
+    if (!isValidIndianPhone(rawPhone)) {
+      setPhoneError('Enter a valid 10-digit mobile number starting with 6–9.')
+      valid = false
+    }
+    if (!name.trim() || name.trim().length < 2) {
+      setNameError('Name must be at least 2 characters.')
+      valid = false
+    }
+    if (!selectedRole) {
+      setRoleError('Please select a role.')
+      valid = false
+    }
+    if (selectedUnitId && !selectedOccupancyType) {
+      setOccupancyError('Please select an occupancy type.')
+      valid = false
+    }
+    if (!valid) return
+
+    setIsSaving(true)
+    try {
+      await directAddMember(societyId, {
+        phone: `+91${rawPhone}`,
+        name: name.trim(),
+        role: selectedRole!,
+        ...(selectedUnitId ? { unitId: selectedUnitId } : {}),
+        ...(selectedOccupancyType ? { occupancyType: selectedOccupancyType } : {}),
+      })
+      setToast({ message: 'Member added successfully.', type: 'success' })
+      setTimeout(() => navigation.goBack(), 1500)
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      const details = getApiErrorDetails(e)
+
+      if (code === 'already_member') {
+        setToast({ message: 'This person is already a member of the society.', type: 'error' })
+      } else if (code === 'inactive_member') {
+        setInactiveMemberId((details as any)?.memberId ?? null)
+        setShowReactivateSheet(true)
+      } else if (code === 'invalid_phone') {
+        setPhoneError('Invalid phone number.')
+      } else if (code === 'invalid_name') {
+        setNameError('Name must be at least 2 characters.')
+      } else if (code === 'role_not_allowed') {
+        setRoleError('You cannot assign this role.')
+      } else {
+        setToast({ message: getErrorMessage(code), type: 'error' })
+      }
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  async function handleReactivateConfirm() {
+    if (!inactiveMemberId) return
+    setReactivateLoading(true)
+    try {
+      await reactivateMember(societyId, inactiveMemberId)
+      setShowReactivateSheet(false)
+      setToast({ message: 'Member access restored.', type: 'success' })
+      setTimeout(() => navigation.goBack(), 1500)
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      setShowReactivateSheet(false)
+      setToast({ message: getErrorMessage(code), type: 'error' })
+    } finally {
+      setReactivateLoading(false)
+    }
+  }
+
+  // ── Picker label helpers ──────────────────────────────────────────────────
+
+  const roleLabelMap = Object.fromEntries(roleOptions.map((o) => [o.value, o.label]))
+  const occupancyLabelMap = Object.fromEntries(OCCUPANCY_TYPE_OPTIONS.map((o) => [o.value, o.label]))
+  const unitLabelMap = Object.fromEntries(unitPickerOptions.map((o) => [o.value, o.label]))
+
+  // ── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <ScreenWrapper scroll={false}>
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* ── Member Details ── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Member Details</Text>
+
+          <TextInput
+            label="Mobile Number"
+            value={phone}
+            onChangeText={handlePhoneChange}
+            keyboardType="phone-pad"
+            maxLength={11}
+            placeholder="98765 43210"
+            error={phoneError}
+            helper="Must be a 10-digit Indian mobile number"
+          />
+
+          <TextInput
+            label="Full Name"
+            value={name}
+            onChangeText={(t) => { setName(t); setNameError('') }}
+            placeholder="Member's full name"
+            error={nameError}
+            maxLength={80}
+          />
+        </View>
+
+        {/* ── Role ── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Role</Text>
+          <View style={styles.field}>
+            <Pressable
+              onPress={() => { setShowRolePicker(true); setRoleError('') }}
+              style={({ pressed }) => [
+                styles.pickerTrigger,
+                selectedRole ? styles.pickerTriggerFilled : null,
+                roleError ? styles.pickerTriggerError : null,
+                pressed && styles.pickerTriggerPressed,
+              ]}
+            >
+              <Text style={[styles.pickerText, !selectedRole && styles.pickerPlaceholder]}>
+                {selectedRole ? roleLabelMap[selectedRole] : 'Select role'}
+              </Text>
+              <Text style={styles.chevron}>⌄</Text>
+            </Pressable>
+            {roleError ? <Text style={styles.fieldError}>{roleError}</Text> : null}
+          </View>
+        </View>
+
+        {/* ── Unit Assignment (optional) ── */}
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Unit Assignment <Text style={styles.optional}>(optional)</Text></Text>
+
+          <View style={styles.field}>
+            <Pressable
+              onPress={() => setShowUnitPicker(true)}
+              style={({ pressed }) => [
+                styles.pickerTrigger,
+                selectedUnitId ? styles.pickerTriggerFilled : null,
+                pressed && styles.pickerTriggerPressed,
+              ]}
+              disabled={unitsLoading}
+            >
+              <Text style={[styles.pickerText, !selectedUnitId && styles.pickerPlaceholder]}>
+                {unitsLoading
+                  ? 'Loading units…'
+                  : selectedUnitId
+                    ? unitLabelMap[selectedUnitId]
+                    : 'No unit assigned'}
+              </Text>
+              <Text style={styles.chevron}>⌄</Text>
+            </Pressable>
+          </View>
+
+          {selectedUnitId ? (
+            <View style={styles.field}>
+              <Text style={styles.fieldLabel}>Occupancy Type</Text>
+              <Pressable
+                onPress={() => { setShowOccupancyPicker(true); setOccupancyError('') }}
+                style={({ pressed }) => [
+                  styles.pickerTrigger,
+                  selectedOccupancyType ? styles.pickerTriggerFilled : null,
+                  occupancyError ? styles.pickerTriggerError : null,
+                  pressed && styles.pickerTriggerPressed,
+                ]}
+              >
+                <Text style={[styles.pickerText, !selectedOccupancyType && styles.pickerPlaceholder]}>
+                  {selectedOccupancyType ? occupancyLabelMap[selectedOccupancyType] : 'Select type'}
+                </Text>
+                <Text style={styles.chevron}>⌄</Text>
+              </Pressable>
+              {occupancyError ? <Text style={styles.fieldError}>{occupancyError}</Text> : null}
+            </View>
+          ) : null}
+        </View>
+
+        <Button
+          label="Add Member"
+          onPress={handleSubmit}
+          loading={isSaving}
+          style={styles.submitBtn}
+        />
+      </ScrollView>
+
+      {/* Pickers */}
+      <BottomSheetPicker
+        visible={showRolePicker}
+        title="Select Role"
+        options={roleOptions}
+        selected={selectedRole}
+        onSelect={(v) => { setSelectedRole(v); setRoleError('') }}
+        onClose={() => setShowRolePicker(false)}
+      />
+
+      <BottomSheetPicker
+        visible={showUnitPicker}
+        title="Select Unit"
+        options={unitPickerOptions}
+        selected={selectedUnitId ?? ''}
+        onSelect={handleUnitSelect}
+        onClose={() => setShowUnitPicker(false)}
+      />
+
+      <BottomSheetPicker
+        visible={showOccupancyPicker}
+        title="Occupancy Type"
+        options={OCCUPANCY_TYPE_OPTIONS}
+        selected={selectedOccupancyType}
+        onSelect={(v) => { setSelectedOccupancyType(v); setOccupancyError('') }}
+        onClose={() => setShowOccupancyPicker(false)}
+      />
+
+      {/* Reactivation sheet */}
+      <ConfirmSheet
+        visible={showReactivateSheet}
+        title="Previously a Member"
+        message="This person was previously a member of this society. Would you like to reactivate their access?"
+        confirmLabel="Reactivate"
+        loading={reactivateLoading}
+        onConfirm={handleReactivateConfirm}
+        onClose={() => setShowReactivateSheet(false)}
+      />
+
+      {toast ? (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          visible={!!toast}
+          onHide={() => setToast(null)}
+        />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  content: {
+    padding: Spacing.screenPadding,
+    gap: Spacing.sectionGap,
+    paddingBottom: 40,
+  },
+
+  section: {
+    gap: Spacing.itemGap,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: Colors.subtle,
+    textTransform: 'uppercase',
+    letterSpacing: 0.8,
+  },
+  optional: {
+    fontSize: 11,
+    fontWeight: '400',
+    textTransform: 'none',
+    letterSpacing: 0,
+    color: Colors.subtle,
+  },
+
+  field: {
+    gap: 6,
+  },
+  fieldLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: Colors.text,
+  },
+  fieldError: {
+    fontSize: 13,
+    color: Colors.error,
+  },
+
+  pickerTrigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: 52,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    backgroundColor: Colors.surface,
+  },
+  pickerTriggerFilled: {
+    borderColor: Colors.primary,
+  },
+  pickerTriggerError: {
+    borderColor: Colors.error,
+  },
+  pickerTriggerPressed: {
+    backgroundColor: Colors.background,
+  },
+  pickerText: {
+    flex: 1,
+    fontSize: 16,
+    color: Colors.text,
+  },
+  pickerPlaceholder: {
+    color: Colors.subtle,
+  },
+  chevron: {
+    fontSize: 20,
+    color: Colors.subtle,
+    lineHeight: 24,
+  },
+
+  submitBtn: {
+    marginTop: 8,
+  },
+})

--- a/apps/mobile/src/screens/members/MemberListScreen.tsx
+++ b/apps/mobile/src/screens/members/MemberListScreen.tsx
@@ -4,15 +4,18 @@ import {
   Text,
   ScrollView,
   Pressable,
+  Alert,
   RefreshControl,
   StyleSheet,
 } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { ScreenWrapper } from '../../components/ScreenWrapper'
 import { LoadingSpinner } from '../../components/LoadingSpinner'
 import { Toast } from '../../components/Toast'
 import { Avatar } from '../../components/Avatar'
 import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
 import { listMembers } from '../../services/members'
 import { getApiErrorCode } from '../../services/api'
 import { getErrorMessage } from '../../utils/errorMessages'
@@ -60,6 +63,35 @@ const OCCUPANCY_LABEL: Record<string, string> = {
 
 export function MemberListScreen({ route, navigation }: Props) {
   const { societyId } = route.params
+  const { permissions } = useAuth()
+  const canInvite = permissions.includes('invitation.create')
+
+  useEffect(() => {
+    if (!canInvite) return
+    navigation.setOptions({
+      headerRight: () => (
+        <Pressable
+          onPress={() => {
+            Alert.alert('Add Member', undefined, [
+              {
+                text: 'Invite via SMS',
+                onPress: () => navigation.navigate('InviteMember', { societyId }),
+              },
+              {
+                text: 'Add Directly',
+                onPress: () => navigation.navigate('DirectAddMember', { societyId }),
+              },
+              { text: 'Cancel', style: 'cancel' },
+            ])
+          }}
+          style={{ padding: 4, marginRight: 4 }}
+          hitSlop={12}
+        >
+          <Ionicons name="person-add-outline" size={22} color={Colors.primary} />
+        </Pressable>
+      ),
+    })
+  }, [canInvite, navigation, societyId])
 
   const [filter, setFilter] = useState<FilterOption>('All')
   const [active, setActive] = useState<Member[]>([])

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -333,17 +333,10 @@ export function DashboardScreen({ route, navigation }: Props) {
       onPress: () => navigation.navigate('Structure', { societyId }),
     },
     {
-      show: canInvite,
-      icon: 'mail-outline' as const,
-      label: 'Invite Member',
-      subtitle: 'Send invitation via SMS',
-      onPress: () => navigation.navigate('InviteMember', { societyId }),
-    },
-    {
       show: canViewMembers,
       icon: 'people-outline' as const,
-      label: 'View Members',
-      subtitle: 'Active residents and staff',
+      label: 'Members',
+      subtitle: 'Manage members and roles',
       onPress: () => navigation.navigate('MemberList', { societyId }),
     },
     {

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -294,7 +294,6 @@ export function DashboardScreen({ route, navigation }: Props) {
 
   // Permission gates — as per MOBILE_CONTEXT.md
   const canViewStructure = permissions.includes('node.view')
-  const canInvite = permissions.includes('invitation.create')
   const canViewMembers = permissions.includes('member.view')
   const canSwitchSociety = memberships.length > 1
   const canViewComplaints =

--- a/apps/mobile/src/services/members.ts
+++ b/apps/mobile/src/services/members.ts
@@ -27,3 +27,19 @@ export async function reactivateMember(societyId: string, memberId: string) {
   const res = await api.patch(`/societies/${societyId}/members/${memberId}/reactivate`)
   return res.data.data
 }
+
+export interface DirectAddMemberParams {
+  phone: string
+  name: string
+  role: string
+  unitId?: string
+  occupancyType?: string
+}
+
+export async function directAddMember(
+  societyId: string,
+  params: DirectAddMemberParams,
+): Promise<{ memberId: string; message: string }> {
+  const res = await api.post(`/societies/${societyId}/members/direct-add`, params)
+  return res.data.data
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -491,3 +491,118 @@ Date: 19 May 2026
 20 items per page using createdAt as cursor.
 No time limit on history — complete record kept in DB.
 UI loads lazily via infinite scroll.
+
+## Decision 047 — Soft delete only for member deactivation
+Date: May 2026
+Deactivation sets Membership.isActive = false.
+No records are ever deleted. Complete history preserved.
+
+## Decision 048 — Ownership preserved on deactivation
+Date: May 2026
+UnitOwnership records are legal records and never ended
+on deactivation. Only UnitOccupancy is ended.
+
+## Decision 049 — Active occupancies ended on deactivation
+Date: May 2026
+All active UnitOccupancy records for the member are
+ended (occupiedUntil = now) when membership deactivated.
+
+## Decision 050 — Last admin protection
+Date: May 2026
+Cannot deactivate the last active Admin in a society.
+Endpoint returns 400 last_admin error.
+
+## Decision 051 — Builder self-protection
+Date: May 2026
+Admin cannot deactivate a Builder.
+Only another Builder can deactivate a Builder.
+
+## Decision 052 — Pending visitor entries not auto-denied
+Date: May 2026
+When a member is deactivated, pending visitor entries
+for their unit are NOT auto-denied.
+Gatekeeper handles them manually.
+Auto-deny would cause confusion if visitor is already
+at gate.
+
+## Decision 053 — Reactivation does not restore unit
+Date: May 2026
+Reactivating a member does not restore their previous
+unit assignment. Admin must reassign unit manually.
+Prevents stale occupancy data if unit was reassigned.
+
+## Decision 054 — Device tokens not deleted on deactivation
+Date: May 2026
+Device tokens are per-user not per-society.
+Deleting tokens would break push for other societies.
+Deactivated member stops receiving society pushes
+because their membership.isActive = false filters
+them out of notification recipients.
+
+## Decision 055 — Direct add creates full account
+Date: May 2026
+Direct add creates Person + User + Membership immediately.
+Member shows as Active in member list, not Pending.
+Person logs in later and finds society already set up.
+
+## Decision 056 — Direct add uses member.remove permission
+Date: May 2026
+Direct add reuses member.remove permission (Builder + Admin).
+Avoids creating a new permission for pilot scale.
+Semantic: "managing members" covers both operations.
+
+## Decision 057 — Admin cannot direct-add Builder or Admin
+Date: May 2026
+Admin can direct-add: Resident, Co-resident, Gatekeeper.
+Builder can direct-add: Admin, Resident, Co-resident, Gatekeeper.
+Enforced in endpoint logic, not just permissions.
+
+## Decision 058 — Phone and name required for direct add
+Date: May 2026
+Both fields mandatory. No anonymous members.
+Person can update their own name after logging in.
+
+## Decision 059 — Unit assignment optional in direct add
+Date: May 2026
+Admin can add member without unit — assign later.
+Useful when unit not yet decided at time of adding.
+
+## Decision 060 — Occupied unit warning in direct add
+Date: May 2026
+If selected unit already has primary occupant,
+new member is added as co-occupant (isPrimary: false).
+No blocking — admin decides.
+
+## Decision 061 — SMS notification on direct add is fire and forget
+Date: May 2026
+SMS sent after successful direct add to notify person.
+SMS failure never blocks the operation.
+No sendSms utility exists — deferred for V1.
+
+## Decision 062 — Inactive member detected during direct add
+Date: May 2026
+If phone matches inactive member, returns 409 inactive_member
+with memberId. Mobile shows reactivation option.
+Reactivation does not restore unit (Decision 053).
+
+## Decision 063 — Direct add wrapped in DB transaction
+Date: May 2026
+All operations atomic: Person + User + Membership + Occupancy.
+If any step fails, nothing is created.
+
+## Decision 064 — Direct add entry via Members list
+Date: May 2026
++ button in MemberListScreen header shows action sheet:
+Invite via SMS → InviteMemberScreen
+Add Directly → DirectAddMemberScreen
+
+## Decision 065 — Invite Member dashboard tile removed
+Date: May 2026
+Functionality preserved via Members list header + button
+which offers both Invite via SMS and Add Directly.
+Single consolidated entry point is cleaner UX.
+
+## Decision 066 — Dashboard tile renamed View Members to Members
+Date: May 2026
+Noun not verb — standard navigation tile pattern.
+MemberList screen header already showed Members correctly.


### PR DESCRIPTION
## What's in this PR

### Direct Add Member
- POST /societies/:id/members/direct-add endpoint
- Role-based restrictions (Admin cannot add Admin/Builder)
- Handles existing users and inactive members
- DB transaction for atomicity + audit logging
- DirectAddMemberScreen with role/unit/occupancy pickers
- Reactivation flow when inactive member detected
- 15 new tests, 294 total passing

### Member UX Improvements
- Members list now has + button (person-add icon)
- Action sheet: Invite via SMS | Add Directly
- InviteMember screen now properly reachable
- Remove Invite Member dashboard tile (redundant)
- Rename View Members → Members on dashboard

### Decisions
- D047-D066 documented in DECISIONS.md