### PR TITLE
feat: society settings and info

### DIFF
--- a/apps/api/prisma/migrations/20260527104205_add_society_photo/migration.sql
+++ b/apps/api/prisma/migrations/20260527104205_add_society_photo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "organizations" ADD COLUMN     "photoUrl" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -68,6 +68,7 @@ model Organization {
   state          String
   pincode        String
   type           OrgType  @default(APARTMENT)
+  photoUrl       String?
   isActive       Boolean  @default(true)
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt

--- a/apps/api/src/routes/societies.ts
+++ b/apps/api/src/routes/societies.ts
@@ -4,6 +4,7 @@ import { requirePermission } from '../middleware/permission'
 import { prisma } from '../lib/prisma'
 import { enforceTenantContext } from '../middleware/tenantContext'
 import { validateRequired } from '../utils/validate'
+import { uploadImage } from '../utils/cloudinary'
 import {
   sendSuccess,
   sendCreated,
@@ -182,8 +183,10 @@ router.get('/:id', authenticate, enforceTenantContext, requirePermission('societ
           state: true,
           pincode: true,
           type: true,
+          photoUrl: true,
           isActive: true,
           createdAt: true,
+          settings: true,
           _count: {
             select: {
               propertyNodes: {
@@ -201,6 +204,10 @@ router.get('/:id', authenticate, enforceTenantContext, requirePermission('societ
         return sendNotFound(res, 'society_not_found')
       }
 
+      const settingsMap = Object.fromEntries(
+        (org.settings ?? []).map(s => [s.key, s.value])
+      )
+
       return sendSuccess(res, {
         id: org.id,
         name: org.name,
@@ -209,10 +216,14 @@ router.get('/:id', authenticate, enforceTenantContext, requirePermission('societ
         state: org.state,
         pincode: org.pincode,
         type: org.type,
+        photoUrl: org.photoUrl ?? null,
         isActive: org.isActive,
         totalUnits: org._count.propertyNodes,
         totalMembers: org._count.memberships,
-        createdAt: org.createdAt
+        createdAt: org.createdAt,
+        contactPhone: settingsMap['contactPhone'] ?? null,
+        contactEmail: settingsMap['contactEmail'] ?? null,
+        description: settingsMap['description'] ?? null,
       })
 
     } catch (error) {
@@ -230,19 +241,31 @@ router.patch('/:id', authenticate, enforceTenantContext, requirePermission('soci
   async (req: AuthRequest, res: Response) => {
     try {
       const { id } = req.params
-      const { name, address, city, state, pincode, type } = req.body
+      const { name, address, city, state, pincode, type, photoUrl } = req.body
 
-      // verify membership
-      const membership = await prisma.membership.findFirst({
+      // verify membership and get caller role
+      const callerMembership = await prisma.membership.findFirst({
         where: {
           userId: req.user!.userId,
           orgId: id,
           isActive: true
-        }
+        },
+        include: { role: true }
       })
 
-      if (!membership) {
+      if (!callerMembership) {
         return sendNotFound(res, 'society_not_found')
+      }
+
+      const callerRole = callerMembership.role.name
+
+      // Admin cannot edit structural fields
+      if (callerRole === 'Admin') {
+        if (name || address || city || state || pincode || type) {
+          return sendError(res, 'not_allowed', 403, {
+            message: 'Admin cannot edit structural society info'
+          })
+        }
       }
 
       // validate type if provided
@@ -261,6 +284,22 @@ router.patch('/:id', authenticate, enforceTenantContext, requirePermission('soci
       if (pincode) updates.pincode = pincode
       if (type)    updates.type    = type
 
+      // handle photo upload if provided
+      if (photoUrl) {
+        if (typeof photoUrl !== 'string') {
+          return sendError(res, 'invalid_photo', 400, {
+            message: 'Invalid photo'
+          })
+        }
+        try {
+          updates.photoUrl = await uploadImage(photoUrl, 'societies')
+        } catch {
+          return sendError(res, 'upload_failed', 500, {
+            message: 'Photo upload failed'
+          })
+        }
+      }
+
       if (Object.keys(updates).length === 0) {
         return sendError(res, 'no_fields_provided', 400)
       }
@@ -278,11 +317,76 @@ router.patch('/:id', authenticate, enforceTenantContext, requirePermission('soci
         state: org.state,
         pincode: org.pincode,
         type: org.type,
+        photoUrl: org.photoUrl ?? null,
         updatedAt: org.updatedAt
       })
 
     } catch (error) {
       console.error('PATCH /societies/:id error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
+// ─────────────────────────────────────────────
+// PATCH /api/societies/:id/settings
+// Update society contact/about settings
+// ─────────────────────────────────────────────
+router.patch(
+  '/:id/settings',
+  authenticate,
+  enforceTenantContext,
+  requirePermission('society.update'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const orgId = req.params.id as string
+      const { contactPhone, contactEmail, description } = req.body
+
+      if (!contactPhone && !contactEmail && !description) {
+        return sendError(res, 'missing_field', 400, {
+          message: 'At least one setting required'
+        })
+      }
+
+      if (contactPhone && typeof contactPhone !== 'string') {
+        return sendError(res, 'invalid_phone', 400, {})
+      }
+      if (contactEmail && typeof contactEmail !== 'string') {
+        return sendError(res, 'invalid_email', 400, {})
+      }
+      if (description && typeof description !== 'string') {
+        return sendError(res, 'invalid_description', 400, {})
+      }
+      if (description && description.trim().length > 300) {
+        return sendError(res, 'description_too_long', 400, {
+          message: 'Description max 300 characters'
+        })
+      }
+
+      const settingsToUpdate = [
+        { key: 'contactPhone', value: contactPhone },
+        { key: 'contactEmail', value: contactEmail },
+        { key: 'description', value: description },
+      ].filter(s => s.value !== undefined && s.value !== null)
+
+      await Promise.all(
+        settingsToUpdate.map(({ key, value }) =>
+          prisma.organizationSetting.upsert({
+            where: { orgId_key: { orgId, key } },
+            create: { orgId, key, value: value as string },
+            update: { value: value as string },
+          })
+        )
+      )
+
+      return sendSuccess(res, {
+        contactPhone: contactPhone ?? undefined,
+        contactEmail: contactEmail ?? undefined,
+        description: description ?? undefined,
+      })
+
+    } catch (error) {
+      console.error('PATCH /societies/:id/settings error:', error)
       return sendServerError(res)
     }
   }

--- a/apps/api/tests/societies.test.ts
+++ b/apps/api/tests/societies.test.ts
@@ -1,10 +1,19 @@
 import request from 'supertest'
 import app from '../src/app'
+import { prisma } from '../src/lib/prisma'
+import { generateToken } from '../src/utils/jwt'
 import { getTokens, getSocietyId } from './setup'
+
+jest.mock('../src/utils/cloudinary', () => ({
+  uploadImage: jest.fn().mockResolvedValue('https://res.cloudinary.com/test/vaastio/societies/photo.jpg'),
+}))
+
+const ADMIN_TEST_PHONE = '+919800001001'
 
 describe('Societies', () => {
   let builderToken: string
   let residentToken: string
+  let adminToken: string
   let societyId: string
 
   beforeAll(async () => {
@@ -12,6 +21,27 @@ describe('Societies', () => {
     builderToken = tokens['Builder']
     residentToken = tokens['Resident']
     societyId = await getSocietyId()
+
+    const adminUser = await prisma.user.create({
+      data: {
+        phone: ADMIN_TEST_PHONE,
+        phoneVerified: true,
+        person: { create: { fullName: 'Test Admin Settings', phone: ADMIN_TEST_PHONE } },
+      },
+    })
+    await prisma.membership.create({
+      data: { userId: adminUser.id, orgId: societyId, roleId: 'role-admin', isActive: true },
+    })
+    adminToken = generateToken({ userId: adminUser.id, orgId: societyId, tokenVersion: 0 })
+  })
+
+  afterAll(async () => {
+    const user = await prisma.user.findFirst({ where: { phone: ADMIN_TEST_PHONE } })
+    if (user) {
+      await prisma.membership.deleteMany({ where: { userId: user.id } })
+      await prisma.person.deleteMany({ where: { userId: user.id } })
+      await prisma.user.delete({ where: { id: user.id } })
+    }
   })
 
   // ─────────────────────────────────────────────
@@ -190,6 +220,140 @@ describe('Societies', () => {
         .send({ type: 'WRONG' })
       expect(res.status).toBe(400)
       expect(res.body.error).toBe('invalid_type')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // GET /societies/:id — settings fields
+  // ─────────────────────────────────────────────
+  describe('GET /societies/:id — settings fields', () => {
+    it('returns photoUrl null when not set', async () => {
+      const res = await request(app)
+        .get(`/api/societies/${societyId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.photoUrl).toBeNull()
+      expect(res.body.data.contactPhone).toBeNull()
+      expect(res.body.data.contactEmail).toBeNull()
+      expect(res.body.data.description).toBeNull()
+    })
+
+    it('returns contactPhone and description after PATCH /settings', async () => {
+      await request(app)
+        .patch(`/api/societies/${societyId}/settings`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ contactPhone: '9876543210', description: 'A nice society' })
+
+      const res = await request(app)
+        .get(`/api/societies/${societyId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.contactPhone).toBe('9876543210')
+      expect(res.body.data.description).toBe('A nice society')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // PATCH /societies/:id — photo + Admin restriction
+  // ─────────────────────────────────────────────
+  describe('PATCH /societies/:id — photo and Admin restriction', () => {
+    it('returns 403 if Admin tries to edit name', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ name: 'Hacked Name' })
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('not_allowed')
+    })
+
+    it('accepts photoUrl as base64 and returns cloudinary URL', async () => {
+      const fakeBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ photoUrl: fakeBase64 })
+      expect(res.status).toBe(200)
+      expect(res.body.data.photoUrl).toBe('https://res.cloudinary.com/test/vaastio/societies/photo.jpg')
+    })
+  })
+
+  // ─────────────────────────────────────────────
+  // PATCH /societies/:id/settings
+  // ─────────────────────────────────────────────
+  describe('PATCH /societies/:id/settings', () => {
+    it('returns 401 with no token', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/settings`)
+        .send({ contactPhone: '9876543210' })
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 400 if no fields provided', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/settings`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({})
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('missing_field')
+    })
+
+    it('successfully sets contactPhone', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/settings`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ contactPhone: '9000000001' })
+      expect(res.status).toBe(200)
+      expect(res.body.data.contactPhone).toBe('9000000001')
+    })
+
+    it('successfully sets contactPhone and description together', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/settings`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ contactPhone: '9000000002', description: 'Updated description' })
+      expect(res.status).toBe(200)
+      expect(res.body.data.contactPhone).toBe('9000000002')
+      expect(res.body.data.description).toBe('Updated description')
+    })
+
+    it('returns updated values in GET /societies/:id', async () => {
+      await request(app)
+        .patch(`/api/societies/${societyId}/settings`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ contactEmail: 'admin@greenvalley.com' })
+
+      const res = await request(app)
+        .get(`/api/societies/${societyId}`)
+        .set('Authorization', `Bearer ${builderToken}`)
+      expect(res.status).toBe(200)
+      expect(res.body.data.contactEmail).toBe('admin@greenvalley.com')
+    })
+
+    it('returns 400 for description over 300 characters', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/settings`)
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({ description: 'x'.repeat(301) })
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('description_too_long')
+    })
+
+    it('allows Admin to update settings', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/settings`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ contactPhone: '9111111199' })
+      expect(res.status).toBe(200)
+      expect(res.body.data.contactPhone).toBe('9111111199')
+    })
+
+    it('returns 403 for Resident', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/settings`)
+        .set('Authorization', `Bearer ${residentToken}`)
+        .send({ contactPhone: '9999999999' })
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('insufficient_permissions')
     })
   })
 })

--- a/apps/mobile/src/hooks/useSociety.ts
+++ b/apps/mobile/src/hooks/useSociety.ts
@@ -9,9 +9,13 @@ interface Society {
   state: string
   pincode: string
   type: string
+  photoUrl: string | null
   isActive: boolean
   totalUnits: number
   totalMembers: number
+  contactPhone: string | null
+  contactEmail: string | null
+  description: string | null
 }
 
 export function useSociety(societyId: string | null) {

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { CreateSocietyScreen } from '../screens/society/CreateSocietyScreen'
 import { DashboardScreen } from '../screens/society/DashboardScreen'
+import { SocietySettingsScreen } from '../screens/society/SocietySettingsScreen'
+import { SocietyInfoScreen } from '../screens/society/SocietyInfoScreen'
 import { StructureScreen } from '../screens/society/StructureScreen'
 import { AddNodeScreen } from '../screens/society/AddNodeScreen'
 import { InviteMemberScreen } from '../screens/society/InviteMemberScreen'
@@ -30,6 +32,8 @@ import { Colors } from '../constants/colors'
 export type AppStackParamList = {
   CreateSociety: { source?: 'dashboard' }
   Dashboard: { societyId: string }
+  SocietySettings: { societyId: string }
+  SocietyInfo: { societyId: string }
   SwitchSociety: undefined
   Structure: { societyId: string }
   AddNode: { societyId: string; parentId?: string; parentName?: string }
@@ -92,6 +96,8 @@ export function AppNavigator({ initialSocietyId }: AppNavigatorProps) {
       <Stack.Screen name="MemberList" component={MemberListScreen} options={{ title: 'Members' }} />
       <Stack.Screen name="MemberDetail" component={MemberDetailScreen} options={({ route }) => ({ title: route.params.memberName })} />
       <Stack.Screen name="DirectAddMember" component={DirectAddMemberScreen} options={{ title: 'Add Member' }} />
+      <Stack.Screen name="SocietySettings" component={SocietySettingsScreen} options={{ title: 'Society Settings' }} />
+      <Stack.Screen name="SocietyInfo" component={SocietyInfoScreen} options={{ title: 'Society Info' }} />
       <Stack.Screen name="SwitchSociety" component={SwitchSocietyScreen} options={{ title: 'Switch Society' }} />
       <Stack.Screen name="ComplaintList" component={ComplaintListScreen} options={{ title: 'Complaints' }} />
       <Stack.Screen name="RaiseComplaint" component={RaiseComplaintScreen} options={{ title: 'Raise Complaint' }} />

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -439,9 +439,10 @@ export function DashboardScreen({ route, navigation }: Props) {
         }
       >
         {/* Society identity + address — tappable → SocietyInfo */}
-        <Pressable
+        <TouchableOpacity
           onPress={() => navigation.navigate('SocietyInfo', { societyId })}
-          style={({ pressed }) => [styles.societyCard, pressed && { opacity: 0.95 }]}
+          activeOpacity={0.8}
+          style={{ flexShrink: 0 }}
         >
           <View style={styles.identityRow}>
             {society.photoUrl ? (
@@ -471,7 +472,7 @@ export function DashboardScreen({ route, navigation }: Props) {
           <Text style={styles.address} numberOfLines={2}>
             {society.address}, {society.city}, {society.state} – {society.pincode}
           </Text>
-        </Pressable>
+        </TouchableOpacity>
 
         {/* Stats — role-specific */}
         {canLogVisitor ? (
@@ -691,10 +692,6 @@ const styles = StyleSheet.create({
     gap: Spacing.sectionGap,
   },
 
-  // Society card
-  societyCard: {
-    // no extra padding — children already have it from content
-  },
   // Identity
   identityRow: {
     flexDirection: 'row',

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -442,7 +442,7 @@ export function DashboardScreen({ route, navigation }: Props) {
         <TouchableOpacity
           onPress={() => navigation.navigate('SocietyInfo', { societyId })}
           activeOpacity={0.8}
-          style={{ flexShrink: 0 }}
+          style={{ flexShrink: 0, gap: 4 }}
         >
           <View style={styles.identityRow}>
             {society.photoUrl ? (
@@ -755,7 +755,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: Colors.subtle,
     lineHeight: 20,
-    marginTop: -Spacing.itemGap,
+    marginTop: 6,
   },
 
   // Stats

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -735,7 +735,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: Colors.border,
     paddingHorizontal: 8,
-    paddingVertical: 3,
+    paddingVertical: 1,
     borderRadius: 6,
   },
   rolePill: {
@@ -746,7 +746,7 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: Colors.border,
     paddingHorizontal: 8,
-    paddingVertical: 3,
+    paddingVertical: 1,
     borderRadius: 6,
   },
 
@@ -755,7 +755,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: Colors.subtle,
     lineHeight: 20,
-    marginTop: 6,
+    marginTop: 10,
   },
 
   // Stats

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -257,7 +257,7 @@ export function DashboardScreen({ route, navigation }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user?.name, navigation])
 
-  // Bell icon (all roles) + "+" button (builders only)
+  // Bell icon (all roles) + gear (Builder/Admin) + "+" button (builders only)
   useEffect(() => {
     navigation.setOptions({
       headerRight: () => (
@@ -278,6 +278,15 @@ export function DashboardScreen({ route, navigation }: Props) {
               )}
             </View>
           </TouchableOpacity>
+          {(role === 'Builder' || role === 'Admin') && (
+            <TouchableOpacity
+              onPress={() => navigation.navigate('SocietySettings', { societyId })}
+              style={styles.headerButton}
+              hitSlop={12}
+            >
+              <Ionicons name="settings-outline" size={22} color={Colors.primary} />
+            </TouchableOpacity>
+          )}
           {canCreateSociety && (
             <TouchableOpacity
               onPress={() => navigation.navigate('CreateSociety', { source: 'dashboard' })}
@@ -290,7 +299,7 @@ export function DashboardScreen({ route, navigation }: Props) {
         </View>
       ),
     })
-  }, [canCreateSociety, unreadCount, navigation, societyId])
+  }, [canCreateSociety, unreadCount, navigation, societyId, role])
 
   // Permission gates — as per MOBILE_CONTEXT.md
   const canViewStructure = permissions.includes('node.view')
@@ -429,32 +438,40 @@ export function DashboardScreen({ route, navigation }: Props) {
           />
         }
       >
-        {/* Society identity */}
-        <View style={styles.identityRow}>
-          <View style={styles.avatar}>
-            <Text style={styles.avatarText}>
-              {society.name.trim().charAt(0).toUpperCase()}
-            </Text>
-          </View>
-          <View style={styles.identityText}>
-            <Text style={styles.societyName} numberOfLines={2}>
-              {society.name}
-            </Text>
-            <View style={styles.metaRow}>
-              {(role === 'Builder' || role === 'Admin') && (
-                <Text style={styles.typePill}>
-                  {SOCIETY_TYPE_LABEL[society.type] ?? society.type}
+        {/* Society identity + address — tappable → SocietyInfo */}
+        <Pressable
+          onPress={() => navigation.navigate('SocietyInfo', { societyId })}
+          style={({ pressed }) => [styles.societyCard, pressed && { opacity: 0.95 }]}
+        >
+          <View style={styles.identityRow}>
+            {society.photoUrl ? (
+              <Image source={{ uri: society.photoUrl }} style={styles.avatar} />
+            ) : (
+              <View style={styles.avatar}>
+                <Text style={styles.avatarText}>
+                  {society.name.trim().charAt(0).toUpperCase()}
                 </Text>
-              )}
-              {role ? <Text style={styles.rolePill}>{role}</Text> : null}
+              </View>
+            )}
+            <View style={styles.identityText}>
+              <Text style={styles.societyName} numberOfLines={2}>
+                {society.name}
+              </Text>
+              <View style={styles.metaRow}>
+                {(role === 'Builder' || role === 'Admin') && (
+                  <Text style={styles.typePill}>
+                    {SOCIETY_TYPE_LABEL[society.type] ?? society.type}
+                  </Text>
+                )}
+                {role ? <Text style={styles.rolePill}>{role}</Text> : null}
+              </View>
             </View>
           </View>
-        </View>
 
-        {/* Address */}
-        <Text style={styles.address} numberOfLines={2}>
-          {society.address}, {society.city}, {society.state} – {society.pincode}
-        </Text>
+          <Text style={styles.address} numberOfLines={2}>
+            {society.address}, {society.city}, {society.state} – {society.pincode}
+          </Text>
+        </Pressable>
 
         {/* Stats — role-specific */}
         {canLogVisitor ? (
@@ -674,6 +691,10 @@ const styles = StyleSheet.create({
     gap: Spacing.sectionGap,
   },
 
+  // Society card
+  societyCard: {
+    // no extra padding — children already have it from content
+  },
   // Identity
   identityRow: {
     flexDirection: 'row',

--- a/apps/mobile/src/screens/society/SocietyInfoScreen.tsx
+++ b/apps/mobile/src/screens/society/SocietyInfoScreen.tsx
@@ -1,0 +1,304 @@
+import React, { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  Image,
+  Pressable,
+  Linking,
+  StyleSheet,
+} from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { LoadingSpinner } from '../../components/LoadingSpinner'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
+import { getSociety } from '../../services/societies'
+import { getApiErrorCode } from '../../services/api'
+import { getErrorMessage } from '../../utils/errorMessages'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'SocietyInfo'>
+
+const SOCIETY_TYPE_LABEL: Record<string, string> = {
+  APARTMENT: 'Apartment',
+  VILLA:     'Villa',
+  MIXED:     'Mixed',
+  PLOTTED:   'Plotted',
+}
+
+interface Society {
+  id: string
+  name: string
+  address: string
+  city: string
+  state: string
+  pincode: string
+  type: string
+  photoUrl: string | null
+  contactPhone: string | null
+  contactEmail: string | null
+  description: string | null
+}
+
+export function SocietyInfoScreen({ route, navigation }: Props) {
+  const { societyId } = route.params
+  const { permissions } = useAuth()
+
+  const canEdit = permissions.includes('society.update')
+
+  useEffect(() => {
+    if (!canEdit) return
+    navigation.setOptions({
+      headerRight: () => (
+        <Pressable
+          onPress={() => navigation.navigate('SocietySettings', { societyId })}
+          style={{ padding: 4, marginRight: 4 }}
+          hitSlop={12}
+        >
+          <Ionicons name="create-outline" size={22} color={Colors.primary} />
+        </Pressable>
+      ),
+    })
+  }, [canEdit, navigation, societyId])
+
+  const [society, setSociety] = useState<Society | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getSociety(societyId)
+        setSociety(data)
+      } catch (e) {
+        const code = getApiErrorCode(e)
+        setErrorMsg(getErrorMessage(code))
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    load()
+  }, [societyId])
+
+  if (isLoading) return <LoadingSpinner fullScreen />
+
+  if (errorMsg || !society) {
+    return (
+      <ScreenWrapper>
+        <View style={styles.errorWrap}>
+          <Text style={styles.errorText}>{errorMsg ?? 'Could not load society info.'}</Text>
+        </View>
+      </ScreenWrapper>
+    )
+  }
+
+  const avatarLetter = society.name.trim().charAt(0).toUpperCase()
+  const fullAddress = [society.address, society.city, society.state, society.pincode]
+    .filter(Boolean)
+    .join(', ')
+
+  return (
+    <ScreenWrapper scroll={false}>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* ── Header card ── */}
+        <View style={styles.headerCard}>
+          {society.photoUrl ? (
+            <Image source={{ uri: society.photoUrl }} style={styles.photo} />
+          ) : (
+            <View style={styles.photoPlaceholder}>
+              <Text style={styles.photoPlaceholderText}>{avatarLetter}</Text>
+            </View>
+          )}
+          <Text style={styles.societyName}>{society.name}</Text>
+          {society.type ? (
+            <View style={styles.typePill}>
+              <Text style={styles.typePillText}>
+                {SOCIETY_TYPE_LABEL[society.type] ?? society.type}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+
+        {/* ── Address ── */}
+        {fullAddress ? (
+          <InfoSection icon="location-outline" label={fullAddress} />
+        ) : null}
+
+        {/* ── Contact Phone ── */}
+        {society.contactPhone ? (
+          <InfoSection
+            icon="call-outline"
+            label={society.contactPhone}
+            onPress={() => Linking.openURL(`tel:${society.contactPhone}`)}
+          />
+        ) : null}
+
+        {/* ── Contact Email ── */}
+        {society.contactEmail ? (
+          <InfoSection
+            icon="mail-outline"
+            label={society.contactEmail}
+            onPress={() => Linking.openURL(`mailto:${society.contactEmail}`)}
+          />
+        ) : null}
+
+        {/* ── Description ── */}
+        {society.description ? (
+          <View style={styles.descSection}>
+            <Text style={styles.descLabel}>About</Text>
+            <Text style={styles.descText}>{society.description}</Text>
+          </View>
+        ) : null}
+      </ScrollView>
+    </ScreenWrapper>
+  )
+}
+
+// ─── Info row ─────────────────────────────────────────────────────────────────
+
+function InfoSection({
+  icon,
+  label,
+  onPress,
+}: {
+  icon: keyof typeof Ionicons.glyphMap
+  label: string
+  onPress?: () => void
+}) {
+  const content = (
+    <View style={infoStyles.row}>
+      <Ionicons name={icon} size={18} color={Colors.subtle} style={infoStyles.icon} />
+      <Text style={[infoStyles.label, onPress ? infoStyles.labelLink : null]}>{label}</Text>
+    </View>
+  )
+
+  if (onPress) {
+    return (
+      <Pressable
+        onPress={onPress}
+        style={({ pressed }) => [infoStyles.wrap, pressed && infoStyles.wrapPressed]}
+      >
+        {content}
+      </Pressable>
+    )
+  }
+
+  return <View style={infoStyles.wrap}>{content}</View>
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  content: {
+    paddingBottom: 48,
+  },
+  headerCard: {
+    alignItems: 'center',
+    paddingVertical: 28,
+    paddingHorizontal: Spacing.screenPadding,
+    gap: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border,
+    backgroundColor: Colors.surface,
+  },
+  photo: {
+    width: 120,
+    height: 120,
+    borderRadius: 24,
+  },
+  photoPlaceholder: {
+    width: 120,
+    height: 120,
+    borderRadius: 24,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  photoPlaceholderText: {
+    fontSize: 48,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  societyName: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: Colors.text,
+    textAlign: 'center',
+  },
+  typePill: {
+    backgroundColor: '#ede9fe',
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+    borderRadius: 20,
+  },
+  typePillText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: Colors.primary,
+  },
+  descSection: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 16,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+    gap: 6,
+  },
+  descLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: Colors.subtle,
+    letterSpacing: 0.6,
+    textTransform: 'uppercase',
+  },
+  descText: {
+    fontSize: 15,
+    color: Colors.text,
+    lineHeight: 22,
+  },
+  errorWrap: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: Spacing.screenPadding,
+  },
+  errorText: {
+    fontSize: 15,
+    color: Colors.subtle,
+    textAlign: 'center',
+  },
+})
+
+const infoStyles = StyleSheet.create({
+  wrap: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingVertical: 14,
+    borderTopWidth: 1,
+    borderTopColor: Colors.border,
+    backgroundColor: Colors.surface,
+  },
+  wrapPressed: {
+    backgroundColor: Colors.background,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  icon: {
+    flexShrink: 0,
+  },
+  label: {
+    fontSize: 15,
+    color: Colors.text,
+    flex: 1,
+  },
+  labelLink: {
+    color: Colors.primary,
+  },
+})

--- a/apps/mobile/src/screens/society/SocietySettingsScreen.tsx
+++ b/apps/mobile/src/screens/society/SocietySettingsScreen.tsx
@@ -206,6 +206,7 @@ export function SocietySettingsScreen({ route }: Props) {
       }
 
       setToast({ message: 'Society updated.', type: 'success' })
+      setTimeout(() => navigation.goBack(), 1000)
     } catch (e) {
       const code = getApiErrorCode(e)
       setToast({ message: getErrorMessage(code), type: 'error' })

--- a/apps/mobile/src/screens/society/SocietySettingsScreen.tsx
+++ b/apps/mobile/src/screens/society/SocietySettingsScreen.tsx
@@ -1,0 +1,514 @@
+import React, { useState, useEffect } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  Alert,
+  StyleSheet,
+  Image,
+  Pressable,
+} from 'react-native'
+import * as ImagePicker from 'expo-image-picker'
+import { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { ScreenWrapper } from '../../components/ScreenWrapper'
+import { TextInput } from '../../components/TextInput'
+import { Button } from '../../components/Button'
+import { BottomSheetPicker, PickerOption } from '../../components/BottomSheetPicker'
+import { Toast } from '../../components/Toast'
+import { AppStackParamList } from '../../navigation/AppNavigator'
+import { useAuth } from '../../hooks/useAuth'
+import {
+  getSociety,
+  updateSociety,
+  updateSocietyPhoto,
+  updateSocietySettings,
+  SocietyType,
+} from '../../services/societies'
+import { getApiErrorCode } from '../../services/api'
+import { getErrorMessage } from '../../utils/errorMessages'
+import { Colors } from '../../constants/colors'
+import { Spacing } from '../../constants/spacing'
+
+type Props = NativeStackScreenProps<AppStackParamList, 'SocietySettings'>
+
+const SOCIETY_TYPES: PickerOption[] = [
+  { label: 'Apartment', value: 'APARTMENT' },
+  { label: 'Villa',     value: 'VILLA' },
+  { label: 'Mixed',     value: 'MIXED' },
+  { label: 'Plotted',   value: 'PLOTTED' },
+]
+
+const TYPE_LABELS: Record<string, string> = {
+  APARTMENT: 'Apartment',
+  VILLA:     'Villa',
+  MIXED:     'Mixed',
+  PLOTTED:   'Plotted',
+}
+
+interface SocietyData {
+  name: string
+  address: string
+  city: string
+  state: string
+  pincode: string
+  type: string
+  photoUrl: string | null
+  contactPhone: string | null
+  contactEmail: string | null
+  description: string | null
+}
+
+export function SocietySettingsScreen({ route }: Props) {
+  const { societyId } = route.params
+  const { memberships } = useAuth()
+
+  const membership = memberships.find((m) => m.org.id === societyId)
+  const callerRole = membership?.role ?? null
+  const isBuilder = callerRole === 'Builder'
+
+  // ── Data state ──
+  const [original, setOriginal] = useState<SocietyData | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  // ── Form fields ──
+  const [name, setName] = useState('')
+  const [address, setAddress] = useState('')
+  const [city, setCity] = useState('')
+  const [state, setState] = useState('')
+  const [pincode, setPincode] = useState('')
+  const [type, setType] = useState<SocietyType | ''>('')
+  const [contactPhone, setContactPhone] = useState('')
+  const [contactEmail, setContactEmail] = useState('')
+  const [description, setDescription] = useState('')
+
+  // ── Photo state ──
+  const [photoBase64, setPhotoBase64] = useState<string | null>(null)
+  const [photoPreviewUri, setPhotoPreviewUri] = useState<string | null>(null)
+
+  // ── UI state ──
+  const [isSaving, setIsSaving] = useState(false)
+  const [typePicker, setTypePicker] = useState(false)
+  const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
+
+  // ── Errors ──
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await getSociety(societyId)
+        setOriginal(data)
+        setName(data.name ?? '')
+        setAddress(data.address ?? '')
+        setCity(data.city ?? '')
+        setState(data.state ?? '')
+        setPincode(data.pincode ?? '')
+        setType(data.type ?? '')
+        setContactPhone(data.contactPhone ?? '')
+        setContactEmail(data.contactEmail ?? '')
+        setDescription(data.description ?? '')
+      } catch {
+        setToast({ message: 'Could not load society details.', type: 'error' })
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    load()
+  }, [societyId])
+
+  async function handlePickPhoto(source: 'camera' | 'library') {
+    if (source === 'camera') {
+      const { status } = await ImagePicker.requestCameraPermissionsAsync()
+      if (status !== 'granted') {
+        setToast({ message: 'Camera permission required.', type: 'info' })
+        return
+      }
+      const result = await ImagePicker.launchCameraAsync({
+        mediaTypes: ['images'],
+        base64: true,
+        quality: 0.7,
+      })
+      if (result.canceled || !result.assets[0]?.base64) return
+      setPhotoBase64(result.assets[0].base64)
+      setPhotoPreviewUri(result.assets[0].uri)
+    } else {
+      const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync()
+      if (status !== 'granted') {
+        setToast({ message: 'Allow photo access to choose an image.', type: 'info' })
+        return
+      }
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ['images'],
+        base64: true,
+        quality: 0.7,
+      })
+      if (result.canceled || !result.assets[0]?.base64) return
+      setPhotoBase64(result.assets[0].base64)
+      setPhotoPreviewUri(result.assets[0].uri)
+    }
+  }
+
+  function showPhotoOptions() {
+    Alert.alert('Change Photo', undefined, [
+      { text: 'Take Photo',          onPress: () => handlePickPhoto('camera') },
+      { text: 'Choose from Gallery', onPress: () => handlePickPhoto('library') },
+      { text: 'Cancel',              style: 'cancel' },
+    ])
+  }
+
+  function validate(): boolean {
+    const next: Record<string, string> = {}
+    if (isBuilder) {
+      if (!name.trim())    next.name    = 'Society name is required.'
+      if (!address.trim()) next.address = 'Address is required.'
+      if (!city.trim())    next.city    = 'City is required.'
+      if (!state.trim())   next.state   = 'State is required.'
+      if (!pincode.trim()) {
+        next.pincode = 'Pincode is required.'
+      } else if (!/^\d{6}$/.test(pincode)) {
+        next.pincode = 'Enter a valid 6-digit pincode.'
+      }
+      if (!type) next.type = 'Please select a society type.'
+    }
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  async function handleSave() {
+    if (!validate()) return
+    setIsSaving(true)
+    try {
+      if (photoBase64) {
+        await updateSocietyPhoto(societyId, photoBase64)
+      }
+
+      if (isBuilder) {
+        const structuralPayload: Record<string, string> = {}
+        if (name.trim()    !== (original?.name    ?? '')) structuralPayload.name    = name.trim()
+        if (address.trim() !== (original?.address ?? '')) structuralPayload.address = address.trim()
+        if (city.trim()    !== (original?.city    ?? '')) structuralPayload.city    = city.trim()
+        if (state.trim()   !== (original?.state   ?? '')) structuralPayload.state   = state.trim()
+        if (pincode.trim() !== (original?.pincode ?? '')) structuralPayload.pincode = pincode.trim()
+        if (type           !== (original?.type    ?? '')) structuralPayload.type    = type as SocietyType
+
+        if (Object.keys(structuralPayload).length > 0) {
+          await updateSociety(societyId, structuralPayload as any)
+        }
+      }
+
+      const settingsPayload: Record<string, string> = {}
+      if (contactPhone.trim() !== (original?.contactPhone ?? '')) settingsPayload.contactPhone = contactPhone.trim()
+      if (contactEmail.trim() !== (original?.contactEmail ?? '')) settingsPayload.contactEmail = contactEmail.trim()
+      if (description.trim()  !== (original?.description  ?? '')) settingsPayload.description  = description.trim()
+
+      if (Object.keys(settingsPayload).length > 0) {
+        await updateSocietySettings(societyId, settingsPayload)
+      }
+
+      setToast({ message: 'Society updated.', type: 'success' })
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      setToast({ message: getErrorMessage(code), type: 'error' })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (isLoading) return null
+
+  const photoSource = photoPreviewUri ?? original?.photoUrl ?? null
+  const avatarLetter = (original?.name ?? '?').trim().charAt(0).toUpperCase()
+
+  return (
+    <ScreenWrapper scroll={false}>
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* ── Society Photo ── */}
+        <SectionHeader title="Society Photo" />
+        <View style={styles.photoSection}>
+          <Pressable onPress={showPhotoOptions} style={styles.photoWrap}>
+            {photoSource ? (
+              <Image source={{ uri: photoSource }} style={styles.photo} />
+            ) : (
+              <View style={styles.photoPlaceholder}>
+                <Text style={styles.photoPlaceholderText}>{avatarLetter}</Text>
+              </View>
+            )}
+          </Pressable>
+          <Pressable onPress={showPhotoOptions} hitSlop={8}>
+            <Text style={styles.changePhotoLabel}>Change Photo</Text>
+          </Pressable>
+        </View>
+
+        {/* ── Basic Info (Builder only) ── */}
+        {isBuilder ? (
+          <>
+            <SectionHeader title="Basic Info" style={styles.sectionGap} />
+            <View style={styles.fields}>
+              <TextInput
+                label="Society Name"
+                value={name}
+                onChangeText={(v) => { setName(v); setErrors((e) => ({ ...e, name: undefined as any })) }}
+                placeholder="e.g. Green Valley Society"
+                error={errors.name}
+                autoCapitalize="words"
+              />
+              <TextInput
+                label="Address"
+                value={address}
+                onChangeText={(v) => { setAddress(v); setErrors((e) => ({ ...e, address: undefined as any })) }}
+                placeholder="e.g. 123 MG Road"
+                error={errors.address}
+                autoCapitalize="words"
+              />
+              <View style={styles.row}>
+                <View style={styles.rowHalf}>
+                  <TextInput
+                    label="City"
+                    value={city}
+                    onChangeText={(v) => { setCity(v); setErrors((e) => ({ ...e, city: undefined as any })) }}
+                    placeholder="Pune"
+                    error={errors.city}
+                    autoCapitalize="words"
+                  />
+                </View>
+                <View style={styles.rowHalf}>
+                  <TextInput
+                    label="State"
+                    value={state}
+                    onChangeText={(v) => { setState(v); setErrors((e) => ({ ...e, state: undefined as any })) }}
+                    placeholder="Maharashtra"
+                    error={errors.state}
+                    autoCapitalize="words"
+                  />
+                </View>
+              </View>
+              <TextInput
+                label="Pincode"
+                value={pincode}
+                onChangeText={(v) => { setPincode(v.replace(/\D/g, '').slice(0, 6)); setErrors((e) => ({ ...e, pincode: undefined as any })) }}
+                placeholder="411001"
+                error={errors.pincode}
+                keyboardType="number-pad"
+                maxLength={6}
+              />
+              <View>
+                <Text style={styles.fieldLabel}>Society Type</Text>
+                <Pressable
+                  onPress={() => setTypePicker(true)}
+                  style={({ pressed }) => [
+                    styles.typePicker,
+                    type ? styles.typePickerFilled : null,
+                    errors.type ? styles.typePickerError : null,
+                    pressed && styles.typePickerPressed,
+                  ]}
+                >
+                  <Text style={[styles.typePickerText, !type && styles.typePickerPlaceholder]}>
+                    {type ? TYPE_LABELS[type] : 'Select type'}
+                  </Text>
+                  <Text style={styles.typePickerChevron}>⌄</Text>
+                </Pressable>
+                {errors.type ? <Text style={styles.fieldError}>{errors.type}</Text> : null}
+              </View>
+            </View>
+          </>
+        ) : null}
+
+        {/* ── Contact & About ── */}
+        <SectionHeader title="Contact & About" style={styles.sectionGap} />
+        <View style={styles.fields}>
+          <TextInput
+            label="Contact Phone"
+            value={contactPhone}
+            onChangeText={setContactPhone}
+            placeholder="e.g. 9876543210"
+            keyboardType="phone-pad"
+            maxLength={15}
+          />
+          <TextInput
+            label="Contact Email"
+            value={contactEmail}
+            onChangeText={setContactEmail}
+            placeholder="e.g. admin@society.com"
+            keyboardType="email-address"
+            autoCapitalize="none"
+          />
+          <View>
+            <TextInput
+              label="Description"
+              value={description}
+              onChangeText={(v) => setDescription(v.slice(0, 300))}
+              placeholder="A brief description of the society…"
+              multiline
+              numberOfLines={4}
+              maxLength={300}
+            />
+            <Text style={styles.charCount}>{description.length}/300</Text>
+          </View>
+        </View>
+
+        <Button
+          label="Save Changes"
+          onPress={handleSave}
+          loading={isSaving}
+          style={styles.saveBtn}
+        />
+      </ScrollView>
+
+      <BottomSheetPicker
+        visible={typePicker}
+        title="Society Type"
+        options={SOCIETY_TYPES}
+        selected={type || null}
+        onSelect={(v) => { setType(v as SocietyType); setErrors((e) => ({ ...e, type: undefined as any })) }}
+        onClose={() => setTypePicker(false)}
+      />
+
+      {toast ? (
+        <Toast
+          message={toast.message}
+          type={toast.type}
+          visible={!!toast}
+          onHide={() => setToast(null)}
+        />
+      ) : null}
+    </ScreenWrapper>
+  )
+}
+
+// ─── Section header ───────────────────────────────────────────────────────────
+
+function SectionHeader({ title, style }: { title: string; style?: object }) {
+  return (
+    <View style={[styles.sectionHeader, style]}>
+      <Text style={styles.sectionTitle}>{title.toUpperCase()}</Text>
+    </View>
+  )
+}
+
+// ─── Styles ───────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  content: {
+    paddingBottom: 48,
+  },
+  sectionHeader: {
+    paddingHorizontal: Spacing.screenPadding,
+    paddingTop: 20,
+    paddingBottom: 10,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: Colors.subtle,
+    letterSpacing: 0.8,
+  },
+  sectionGap: {
+    marginTop: 8,
+  },
+  photoSection: {
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 8,
+  },
+  photoWrap: {
+    width: 80,
+    height: 80,
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  photo: {
+    width: 80,
+    height: 80,
+  },
+  photoPlaceholder: {
+    width: 80,
+    height: 80,
+    borderRadius: 20,
+    backgroundColor: Colors.primary,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  photoPlaceholderText: {
+    fontSize: 30,
+    fontWeight: '700',
+    color: '#fff',
+  },
+  changePhotoLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: Colors.primary,
+  },
+  fields: {
+    paddingHorizontal: Spacing.screenPadding,
+    gap: Spacing.itemGap + 2,
+    backgroundColor: Colors.surface,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    borderColor: Colors.border,
+    paddingVertical: Spacing.screenPadding,
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 10,
+  },
+  rowHalf: {
+    flex: 1,
+  },
+  fieldLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: Colors.text,
+    marginBottom: 6,
+  },
+  typePicker: {
+    height: 52,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: Colors.surface,
+  },
+  typePickerFilled: {
+    borderColor: Colors.primary,
+  },
+  typePickerError: {
+    borderColor: Colors.error,
+  },
+  typePickerPressed: {
+    backgroundColor: Colors.background,
+  },
+  typePickerText: {
+    fontSize: 16,
+    color: Colors.text,
+  },
+  typePickerPlaceholder: {
+    color: Colors.subtle,
+  },
+  typePickerChevron: {
+    fontSize: 20,
+    color: Colors.subtle,
+    lineHeight: 24,
+  },
+  fieldError: {
+    fontSize: 13,
+    color: Colors.error,
+    marginTop: 4,
+  },
+  charCount: {
+    fontSize: 12,
+    color: Colors.subtle,
+    textAlign: 'right',
+    marginTop: 4,
+  },
+  saveBtn: {
+    marginHorizontal: Spacing.screenPadding,
+    marginTop: Spacing.sectionGap,
+  },
+})

--- a/apps/mobile/src/services/societies.ts
+++ b/apps/mobile/src/services/societies.ts
@@ -11,6 +11,12 @@ export interface CreateSocietyPayload {
   type: SocietyType
 }
 
+export interface SocietySettings {
+  contactPhone?: string
+  contactEmail?: string
+  description?: string
+}
+
 export async function createSociety(payload: CreateSocietyPayload) {
   const res = await api.post('/societies', payload)
   return res.data.data
@@ -29,4 +35,12 @@ export async function getSociety(id: string) {
 export async function updateSociety(id: string, payload: Partial<CreateSocietyPayload>) {
   const res = await api.patch(`/societies/${id}`, payload)
   return res.data.data
+}
+
+export async function updateSocietyPhoto(id: string, photoUrl: string): Promise<void> {
+  await api.patch(`/societies/${id}`, { photoUrl })
+}
+
+export async function updateSocietySettings(id: string, settings: SocietySettings): Promise<void> {
+  await api.patch(`/societies/${id}/settings`, settings)
 }

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -540,69 +540,110 @@ because their membership.isActive = false filters
 them out of notification recipients.
 
 ## Decision 055 — Direct add creates full account
-Date: May 2026
+Date: 26 May 2026
 Direct add creates Person + User + Membership immediately.
 Member shows as Active in member list, not Pending.
 Person logs in later and finds society already set up.
 
 ## Decision 056 — Direct add uses member.remove permission
-Date: May 2026
+Date: 26 May 2026
 Direct add reuses member.remove permission (Builder + Admin).
 Avoids creating a new permission for pilot scale.
 Semantic: "managing members" covers both operations.
 
 ## Decision 057 — Admin cannot direct-add Builder or Admin
-Date: May 2026
+Date: 26 May 2026
 Admin can direct-add: Resident, Co-resident, Gatekeeper.
 Builder can direct-add: Admin, Resident, Co-resident, Gatekeeper.
 Enforced in endpoint logic, not just permissions.
 
 ## Decision 058 — Phone and name required for direct add
-Date: May 2026
+Date: 26 May 2026
 Both fields mandatory. No anonymous members.
 Person can update their own name after logging in.
 
 ## Decision 059 — Unit assignment optional in direct add
-Date: May 2026
+Date: 26 May 2026
 Admin can add member without unit — assign later.
 Useful when unit not yet decided at time of adding.
 
 ## Decision 060 — Occupied unit warning in direct add
-Date: May 2026
+Date: 26 May 2026
 If selected unit already has primary occupant,
 new member is added as co-occupant (isPrimary: false).
 No blocking — admin decides.
 
 ## Decision 061 — SMS notification on direct add is fire and forget
-Date: May 2026
+Date: 26 May 2026
 SMS sent after successful direct add to notify person.
 SMS failure never blocks the operation.
 No sendSms utility exists — deferred for V1.
 
 ## Decision 062 — Inactive member detected during direct add
-Date: May 2026
+Date: 26 May 2026
 If phone matches inactive member, returns 409 inactive_member
 with memberId. Mobile shows reactivation option.
 Reactivation does not restore unit (Decision 053).
 
 ## Decision 063 — Direct add wrapped in DB transaction
-Date: May 2026
+Date: 26 May 2026
 All operations atomic: Person + User + Membership + Occupancy.
 If any step fails, nothing is created.
 
 ## Decision 064 — Direct add entry via Members list
-Date: May 2026
+Date: 26 May 2026
 + button in MemberListScreen header shows action sheet:
 Invite via SMS → InviteMemberScreen
 Add Directly → DirectAddMemberScreen
 
 ## Decision 065 — Invite Member dashboard tile removed
-Date: May 2026
+Date: 26 May 2026
 Functionality preserved via Members list header + button
 which offers both Invite via SMS and Add Directly.
 Single consolidated entry point is cleaner UX.
 
 ## Decision 066 — Dashboard tile renamed View Members to Members
-Date: May 2026
+Date: 26 May 2026
 Noun not verb — standard navigation tile pattern.
 MemberList screen header already showed Members correctly.
+
+## Decision 067 — Society photoUrl on Organization model
+Date: 27 May 2026
+photoUrl added directly to Organization model as a column.
+Structural field used everywhere like member photos.
+Uploaded to Cloudinary vaastio/societies/ folder.
+Requires migration.
+
+## Decision 068 — Society settings in OrganizationSetting table
+Date: 27 May 2026
+contactPhone, contactEmail, description stored as
+key-value pairs in existing OrganizationSetting table.
+Flexible — new settings can be added later without
+schema changes. Upserted via PATCH /societies/:id/settings.
+
+## Decision 069 — Admin cannot edit structural society info
+Date: 27 May 2026
+Admin can edit: photo, contactPhone, contactEmail, description.
+Admin cannot edit: name, address, city, state, pincode, type.
+Structural info is builder-owned — they created the project.
+Enforced in endpoint logic not just permissions.
+
+## Decision 070 — Society type fixed after creation
+Date: 27 May 2026
+OrgType (APARTMENT/VILLA/MIXED/PLOTTED) cannot be changed
+after society is created. Changing type mid-way causes
+confusion in unit structure and member expectations.
+Omitted from PATCH /societies/:id for Admin role.
+
+## Decision 071 — Society info read-only for residents
+Date: 27 May 2026
+Residents see: photo, name, description, contactPhone,
+contactEmail via SocietyInfoScreen (read-only).
+They cannot edit anything.
+Contact phone shown with tap-to-call button.
+
+## Decision 072 — Society card on dashboard shows photo
+Date: 27 May 2026
+If society has photoUrl set, shown on dashboard card
+replacing the letter avatar.
+Falls back to letter avatar if no photo.

--- a/docs/briefs/society-settings.md
+++ b/docs/briefs/society-settings.md
@@ -1,0 +1,46 @@
+# Society Settings — Feature Brief
+
+## Overview
+Allow builders and admins to manage society profile
+information. Residents get a read-only info view.
+
+## Who Can Edit What
+
+### Builder
+- Society name, address, city, state, pincode, type
+- Society photo
+- Contact phone, contact email, description
+
+### Admin  
+- Society photo
+- Contact phone, contact email, description
+- Cannot edit name, address, type (structural info)
+
+### Resident / Co-resident / Gatekeeper
+- Read-only view: photo, name, description,
+  contact phone, contact email
+
+## Schema Changes
+- Add photoUrl String? to Organization model
+- contactPhone, contactEmail, description stored
+  in existing OrganizationSetting table (key-value)
+
+## Endpoints
+- PATCH /societies/:id — extended with photoUrl
+- PATCH /societies/:id/settings — NEW
+  Accepts: contactPhone, contactEmail, description
+- GET /societies/:id — extended to return new fields
+  including settings from OrganizationSetting
+
+## Mobile Screens
+- SocietySettingsScreen — edit view (Builder/Admin)
+- SocietyInfoScreen — read-only view (all roles)
+- DashboardScreen — society card shows photo
+
+## Decisions
+- D067: photoUrl on Organization model (structural field)
+- D068: contactPhone/email/description in OrganizationSetting
+- D069: Admin cannot edit name/address/type
+- D070: Society type fixed after creation
+- D071: Society photo uploaded to vaastio/societies/ folder
+- D072: Residents see contact info but cannot edit


### PR DESCRIPTION
## What's in this PR

### Society Settings (Builder/Admin)
- Society photo upload (Cloudinary vaastio/societies/)
- Edit contact phone, email, description
- Builder can also edit name, address, type
- Admin blocked from editing structural fields
- Gear icon in dashboard header → Society Settings

### Society Info (all roles)
- Tap society card on dashboard → Society Info screen
- Shows photo, description, contact phone, email
- Tap phone → opens dialer
- Tap email → opens mail app
- Edit button visible only for Builder/Admin

### Backend
- photoUrl added to Organization model + migration
- GET /societies/:id returns new fields
- PATCH /societies/:id accepts photo upload
- PATCH /societies/:id/settings new endpoint
- Admin restriction enforced server-side
- 12 new tests, 306 total passing

### Decisions D067-D072 documented