### PR TITLE
feat: society handover - builder leaves society

### DIFF
--- a/apps/api/src/routes/members.ts
+++ b/apps/api/src/routes/members.ts
@@ -498,7 +498,22 @@ router.patch(
           }
         })
         if (activeAdminCount === 1) {
-          // allow but warn — builder still has access
+          // Block if no Builder remains — society would be unmanageable
+          const activeBuilderCount = await prisma.membership.count({
+            where: {
+              orgId: id,
+              isActive: true,
+              role: { name: 'Builder' }
+            }
+          })
+
+          if (activeBuilderCount === 0) {
+            return sendError(res, 'last_admin_no_builder', 400, {
+              message: 'Cannot deactivate the last Admin when no Builder exists in the society.'
+            })
+          }
+
+          // Builder exists — allow but warn
           await prisma.membership.update({
             where: { id: memberId },
             data: { isActive: false }

--- a/apps/api/src/routes/societies.ts
+++ b/apps/api/src/routes/societies.ts
@@ -392,4 +392,104 @@ router.patch(
   }
 )
 
+// ─────────────────────────────────────────────
+// PATCH /api/societies/:id/leave
+// Builder hands over and leaves the society
+// ─────────────────────────────────────────────
+router.patch(
+  '/:id/leave',
+  authenticate,
+  enforceTenantContext,
+  requirePermission('society.view'),
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const orgId = req.params.id as string
+      const userId = req.user!.userId
+
+      // 1. Find caller's membership and role
+      const membership = await prisma.membership.findFirst({
+        where: { userId, orgId, isActive: true },
+        include: { role: true }
+      })
+
+      if (!membership) {
+        return sendNotFound(res, 'membership_not_found')
+      }
+
+      // 2. Only Builder can use this endpoint
+      if (membership.role.name !== 'Builder') {
+        return sendError(res, 'not_allowed', 403, {
+          message: 'Only a Builder can leave a society via handover'
+        })
+      }
+
+      // 3. Guard: at least one active Admin must exist
+      const activeAdminCount = await prisma.membership.count({
+        where: {
+          orgId,
+          isActive: true,
+          role: { name: 'Admin' }
+        }
+      })
+
+      if (activeAdminCount === 0) {
+        return sendError(res, 'no_admin_exists', 400, {
+          message: 'You must add an Admin before leaving. They will manage the society after you.'
+        })
+      }
+
+      // 4. Guard: society must have other active members
+      const otherActiveMemberCount = await prisma.membership.count({
+        where: {
+          orgId,
+          isActive: true,
+          userId: { not: userId }
+        }
+      })
+
+      if (otherActiveMemberCount === 0) {
+        return sendError(res, 'no_other_members', 400, {
+          message: 'You are the only member. Add members before leaving.'
+        })
+      }
+
+      // 5. Execute in transaction
+      await prisma.$transaction(async (tx) => {
+        // Deactivate membership
+        await tx.membership.update({
+          where: { id: membership.id },
+          data: { isActive: false }
+        })
+
+        // Increment tokenVersion — invalidates all active JWTs
+        await tx.user.update({
+          where: { id: userId },
+          data: { tokenVersion: { increment: 1 } }
+        })
+
+        // Audit log
+        await tx.auditLog.create({
+          data: {
+            orgId,
+            tableName: 'memberships',
+            recordId: membership.id,
+            action: 'society_leave',
+            actorId: userId,
+            oldData: { isActive: true, role: membership.role.name },
+            newData: { isActive: false, reason: 'builder_handover' }
+          }
+        })
+      })
+
+      return sendSuccess(res, {
+        message: 'You have successfully left the society.'
+      })
+
+    } catch (error) {
+      console.error('PATCH /societies/:id/leave error:', error)
+      return sendServerError(res)
+    }
+  }
+)
+
 export default router

--- a/apps/api/tests/societies.test.ts
+++ b/apps/api/tests/societies.test.ts
@@ -356,4 +356,71 @@ describe('Societies', () => {
       expect(res.body.error).toBe('insufficient_permissions')
     })
   })
+
+  // ─────────────────────────────────────────────
+  // PATCH /societies/:id/leave
+  // ─────────────────────────────────────────────
+  describe('PATCH /societies/:id/leave', () => {
+    it('returns 401 with no token', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/leave`)
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 403 if caller is not Builder', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/leave`)
+        .set('Authorization', `Bearer ${residentToken}`)
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('not_allowed')
+    })
+
+    it('returns 403 if Admin tries to leave', async () => {
+      const res = await request(app)
+        .patch(`/api/societies/${societyId}/leave`)
+        .set('Authorization', `Bearer ${adminToken}`)
+      expect(res.status).toBe(403)
+      expect(res.body.error).toBe('not_allowed')
+    })
+
+    it('returns 400 if no active Admin exists', async () => {
+      // Create a fresh society with only a builder — no admin
+      const createRes = await request(app)
+        .post('/api/societies')
+        .set('Authorization', `Bearer ${builderToken}`)
+        .send({
+          name: 'Leave Guard Test Society',
+          address: '1 Test Lane',
+          city: 'Dehradun',
+          state: 'Uttarakhand',
+          pincode: '248001',
+          type: 'APARTMENT',
+        })
+      expect(createRes.status).toBe(201)
+      const noAdminSocietyId = createRes.body.data.id
+
+      // Get builder user id from token to build a scoped token
+      const builderUser = await prisma.user.findFirst({
+        where: { memberships: { some: { orgId: noAdminSocietyId, isActive: true } } }
+      })
+      const scopedToken = generateToken({
+        userId: builderUser!.id,
+        orgId: noAdminSocietyId,
+        tokenVersion: 0,
+      })
+
+      const res = await request(app)
+        .patch(`/api/societies/${noAdminSocietyId}/leave`)
+        .set('Authorization', `Bearer ${scopedToken}`)
+      expect(res.status).toBe(400)
+      expect(res.body.error).toBe('no_admin_exists')
+    })
+
+    // TODO: full integration test — builder leaves after admin is present,
+    // verify membership deactivated and tokenVersion incremented.
+    // Requires creating an isolated society, adding an admin, then leaving.
+    // Skipped for now to avoid mutating the shared builderToken account.
+    it.todo('deactivates builder membership and increments tokenVersion after leave')
+    it.todo('old builder JWT returns 401 after leave')
+  })
 })

--- a/apps/mobile/src/navigation/AppNavigator.tsx
+++ b/apps/mobile/src/navigation/AppNavigator.tsx
@@ -30,7 +30,7 @@ import { NotificationsScreen } from '../screens/notifications/NotificationsScree
 import { Colors } from '../constants/colors'
 
 export type AppStackParamList = {
-  CreateSociety: { source?: 'dashboard' }
+  CreateSociety: { source?: 'dashboard'; handoverComplete?: boolean }
   Dashboard: { societyId: string }
   SocietySettings: { societyId: string }
   SocietyInfo: { societyId: string }

--- a/apps/mobile/src/screens/members/MemberDetailScreen.tsx
+++ b/apps/mobile/src/screens/members/MemberDetailScreen.tsx
@@ -297,8 +297,8 @@ export function MemberDetailScreen({ route, navigation }: Props) {
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>Actions</Text>
             <View style={styles.actionButtons}>
-              {/* Assign Unit — admin/builder only */}
-              {canAssignUnit ? (
+              {/* Assign Unit — admin/builder only, active members only */}
+              {canAssignUnit && isActive ? (
                 <Button
                   label="Assign Unit"
                   variant="primary"

--- a/apps/mobile/src/screens/society/CreateSocietyScreen.tsx
+++ b/apps/mobile/src/screens/society/CreateSocietyScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { View, Text, Pressable, StyleSheet, ScrollView, TouchableOpacity } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
 import { ScreenWrapper } from '../../components/ScreenWrapper'
 import { TextInput } from '../../components/TextInput'
@@ -51,6 +52,7 @@ interface FormErrors {
 
 export function CreateSocietyScreen({ route, navigation }: Props) {
   const source = route.params?.source
+  const handoverComplete = route.params?.handoverComplete ?? false
   const { loadUser, signOut } = useAuth()
   const [form, setForm] = useState<FormState>({
     name: '',
@@ -126,6 +128,15 @@ export function CreateSocietyScreen({ route, navigation }: Props) {
 
   return (
     <ScreenWrapper>
+      {handoverComplete && (
+        <View style={styles.handoverBanner}>
+          <Ionicons name="checkmark-circle" size={20} color="#16a34a" />
+          <Text style={styles.handoverBannerText}>
+            Society handed over successfully. You can create a new society or join another.
+          </Text>
+        </View>
+      )}
+
       <View style={styles.header}>
         <Text style={styles.title}>Create Society</Text>
         <Text style={styles.subtitle}>Set up your residential society in minutes</Text>
@@ -246,6 +257,23 @@ export function CreateSocietyScreen({ route, navigation }: Props) {
 }
 
 const styles = StyleSheet.create({
+  handoverBanner: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 10,
+    backgroundColor: '#f0fdf4',
+    borderWidth: 1,
+    borderColor: '#bbf7d0',
+    borderRadius: 10,
+    padding: 14,
+    marginBottom: Spacing.sectionGap,
+  },
+  handoverBannerText: {
+    flex: 1,
+    fontSize: 14,
+    color: '#15803d',
+    lineHeight: 20,
+  },
   header: {
     marginBottom: Spacing.sectionGap,
     gap: 6,

--- a/apps/mobile/src/screens/society/SocietySettingsScreen.tsx
+++ b/apps/mobile/src/screens/society/SocietySettingsScreen.tsx
@@ -22,6 +22,7 @@ import {
   updateSociety,
   updateSocietyPhoto,
   updateSocietySettings,
+  leaveSociety,
   SocietyType,
 } from '../../services/societies'
 import { getApiErrorCode } from '../../services/api'
@@ -60,7 +61,7 @@ interface SocietyData {
 
 export function SocietySettingsScreen({ route, navigation }: Props) {
   const { societyId } = route.params
-  const { memberships } = useAuth()
+  const { memberships, loadUser } = useAuth()
 
   const membership = memberships.find((m) => m.org.id === societyId)
   const callerRole = membership?.role ?? null
@@ -87,6 +88,7 @@ export function SocietySettingsScreen({ route, navigation }: Props) {
 
   // ── UI state ──
   const [isSaving, setIsSaving] = useState(false)
+  const [isLeaving, setIsLeaving] = useState(false)
   const [typePicker, setTypePicker] = useState(false)
   const [toast, setToast] = useState<{ message: string; type: 'error' | 'success' | 'info' } | null>(null)
 
@@ -212,6 +214,51 @@ export function SocietySettingsScreen({ route, navigation }: Props) {
       setToast({ message: getErrorMessage(code), type: 'error' })
     } finally {
       setIsSaving(false)
+    }
+  }
+
+  function handleLeave() {
+    Alert.alert(
+      'Leave Society?',
+      `You will lose access to ${original?.name ?? 'this society'}. The Admin will manage it going forward. This cannot be undone.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Continue', style: 'destructive', onPress: showFinalConfirmation },
+      ]
+    )
+  }
+
+  function showFinalConfirmation() {
+    Alert.alert(
+      'Are you absolutely sure?',
+      'Once you leave, you cannot rejoin without admin approval. All society data will be preserved.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Yes, Leave Society', style: 'destructive', onPress: executeLeave },
+      ]
+    )
+  }
+
+  async function executeLeave() {
+    setIsLeaving(true)
+    try {
+      await leaveSociety(societyId)
+      await loadUser()
+      navigation.reset({
+        index: 0,
+        routes: [{ name: 'CreateSociety', params: { handoverComplete: true } }],
+      })
+    } catch (e) {
+      const code = getApiErrorCode(e)
+      if (code === 'no_admin_exists') {
+        setToast({ message: 'Add an Admin before leaving the society.', type: 'error' })
+      } else if (code === 'no_other_members') {
+        setToast({ message: 'Add members before leaving the society.', type: 'error' })
+      } else {
+        setToast({ message: getErrorMessage(code), type: 'error' })
+      }
+    } finally {
+      setIsLeaving(false)
     }
   }
 
@@ -357,6 +404,24 @@ export function SocietySettingsScreen({ route, navigation }: Props) {
           loading={isSaving}
           style={styles.saveBtn}
         />
+
+        {isBuilder && (
+          <View style={styles.dangerSection}>
+            <View style={styles.dangerDivider} />
+            <Text style={styles.dangerTitle}>Danger Zone</Text>
+            <Text style={styles.dangerDescription}>
+              Leaving this society will remove your access permanently.
+              Make sure an Admin is set up to manage the society.
+            </Text>
+            <Button
+              label="Leave Society"
+              onPress={handleLeave}
+              loading={isLeaving}
+              variant="secondary"
+              style={styles.leaveBtn}
+            />
+          </View>
+        )}
       </ScrollView>
 
       <BottomSheetPicker
@@ -511,5 +576,30 @@ const styles = StyleSheet.create({
   saveBtn: {
     marginHorizontal: Spacing.screenPadding,
     marginTop: Spacing.sectionGap,
+  },
+  dangerSection: {
+    marginTop: Spacing.sectionGap,
+    marginHorizontal: Spacing.screenPadding,
+    marginBottom: Spacing.sectionGap,
+  },
+  dangerDivider: {
+    height: 1,
+    backgroundColor: Colors.error + '33',
+    marginBottom: Spacing.sectionGap,
+  },
+  dangerTitle: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: Colors.error,
+    marginBottom: 6,
+  },
+  dangerDescription: {
+    fontSize: 13,
+    color: Colors.subtle,
+    lineHeight: 20,
+    marginBottom: 16,
+  },
+  leaveBtn: {
+    borderColor: Colors.error,
   },
 })

--- a/apps/mobile/src/screens/society/SocietySettingsScreen.tsx
+++ b/apps/mobile/src/screens/society/SocietySettingsScreen.tsx
@@ -58,7 +58,7 @@ interface SocietyData {
   description: string | null
 }
 
-export function SocietySettingsScreen({ route }: Props) {
+export function SocietySettingsScreen({ route, navigation }: Props) {
   const { societyId } = route.params
   const { memberships } = useAuth()
 

--- a/apps/mobile/src/services/societies.ts
+++ b/apps/mobile/src/services/societies.ts
@@ -44,3 +44,8 @@ export async function updateSocietyPhoto(id: string, photoUrl: string): Promise<
 export async function updateSocietySettings(id: string, settings: SocietySettings): Promise<void> {
   await api.patch(`/societies/${id}/settings`, settings)
 }
+
+export async function leaveSociety(societyId: string): Promise<{ message: string }> {
+  const res = await api.patch(`/societies/${societyId}/leave`)
+  return res.data.data
+}

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -647,3 +647,61 @@ Date: 27 May 2026
 If society has photoUrl set, shown on dashboard card
 replacing the letter avatar.
 Falls back to letter avatar if no photo.
+
+## Decision 073 — Handover V1 scope: Builder leaves society
+Date: 31 May 2026
+V1 handover = Builder deactivates own membership.
+Full role transfer (promoting Admin to Builder level)
+deferred to V2. Covers 80% of real handover scenarios.
+Builder who just stops using app is also acceptable
+for pilot scale.
+
+## Decision 074 — Leave society requires active Admin
+Date: 31 May 2026
+Builder cannot leave if no active Admin exists.
+Prevents society becoming unmanaged.
+Error shown: "Add an Admin before leaving."
+Last admin protection also updated: when no Builder
+exists in society, last Admin cannot be deactivated.
+
+## Decision 075 — tokenVersion incremented on leave
+Date: 31 May 2026
+When Builder leaves, user.tokenVersion incremented.
+All active JWT sessions immediately invalidated.
+Builder must re-login to access other societies.
+Security: prevents stale token from accessing
+society after membership deactivated.
+
+## Decision 076 — Admin structural edit limitation after handover
+Date: 31 May 2026
+Admin cannot edit society name, address, type after
+Builder leaves. Accepted V1 limitation.
+Society name and address rarely change post-construction.
+Fix in V2 via role promotion or Society Owner role.
+
+## Decision 077 — Builder reactivation via support only
+Date: 31 May 2026
+If Builder wants to rejoin after leaving,
+requires manual reactivation by Inspirebyte team.
+Self-reactivation flow deferred to V2.
+Admin cannot reactivate Builder (existing rule).
+
+## Decision 078 — Two confirmation dialogs for Leave Society
+Date: 31 May 2026
+Destructive action requires double confirmation.
+Dialog 1: summary of what will happen
+Dialog 2: final irreversible warning
+No OTP confirmation — too much friction for pilot.
+
+## Decision 079 — Builder data preserved after leave
+Date: 31 May 2026
+All Builder-created content preserved after leaving:
+announcements, complaints, units, structure.
+createdBy references remain for audit trail.
+No orphaned data. Society continues without interruption.
+
+## Decision 080 — Leave Society entry via Society Settings
+Date: 31 May 2026
+"Leave Society" button at bottom of SocietySettingsScreen.
+Styled as destructive (red). Visible to Builder only.
+Not in profile — this is a society-level action.

--- a/docs/briefs/society-handover.md
+++ b/docs/briefs/society-handover.md
@@ -1,0 +1,57 @@
+# Society Handover — Feature Brief
+
+## Overview
+Allow a Builder to formally leave a society, transferring
+day-to-day management to the Admin/RWA. This represents
+the end of the builder's active involvement in the society.
+
+## V1 Scope
+Builder leaves society (deactivates own membership).
+Full role transfer (Builder → Admin promotion) is V2.
+
+## Who Can Do This
+Builder only. Admin cannot trigger handover.
+
+## Pre-conditions (enforced before leave allowed)
+1. At least one active Admin must exist in society
+2. Society must have at least one other active member
+
+## What Happens On Leave
+1. Builder membership set to isActive: false
+2. user.tokenVersion incremented (all sessions invalidated)
+3. AuditLog entry written
+4. Builder redirected away from this society
+
+## What Does NOT Happen
+- Data is not deleted
+- Other members unaffected
+- Society continues normally under Admin
+- Builder-created content (announcements, complaints etc)
+  preserved with historical createdBy reference
+
+## Post-Leave Limitations (V1)
+- Admin cannot edit structural society info
+  (name, address, type) — accepted V1 limitation
+- Builder reactivation requires Inspirebyte support
+- No self-reactivation flow
+
+## Entry Point
+Society Settings screen → "Leave Society" button
+at the bottom, styled as destructive action.
+Only visible to Builder role.
+
+## Flow
+1. Tap "Leave Society"
+2. System checks: active Admin exists?
+   No → block with guidance message
+3. Two confirmation dialogs (destructive action)
+4. API call → leave
+5. Navigate away from society
+
+## Endpoint
+PATCH /societies/:id/leave
+Auth: Builder only (enforced in logic, not just permission)
+Guards: active Admin must exist
+
+## Decisions
+D073-D080 (see DECISIONS.md)


### PR DESCRIPTION
## What's in this PR

### Society Handover
Builder can now formally leave a society after handover.

- "Leave Society" button in Society Settings (Builder only)
- Two confirmation dialogs (destructive action)
- Guards: requires active Admin + other members
- Atomic transaction: deactivates membership +
  invalidates JWT (tokenVersion increment) + audit log
- Builder redirected to Create Society with success banner
- Admin takes full control after Builder leaves

### Security Fix
tokenVersion now incremented on leave — all active
Builder sessions invalidated immediately after handover.

### Bug Fixes
- Fix navigation prop missing in SocietySettingsScreen
- Hide Assign Unit button for inactive members
- Last Admin protection updated: blocks deactivating
  last Admin when no Builder exists in society

### Tests
310 passing, 2 todo (integration tests for destructive
handover flow — require isolated test environment)