### PR TITLE
perf: loading improvements

### DIFF
--- a/apps/mobile/src/screens/announcements/AnnouncementsListScreen.tsx
+++ b/apps/mobile/src/screens/announcements/AnnouncementsListScreen.tsx
@@ -139,7 +139,7 @@ export function AnnouncementsListScreen({ route, navigation }: Props) {
     )
   }
 
-  if (isLoading) return <LoadingSpinner fullScreen />
+  if (isLoading && announcements.length === 0) return <LoadingSpinner fullScreen />
 
   return (
     <ScreenWrapper scroll={false} style={styles.wrapper}>

--- a/apps/mobile/src/screens/complaints/ComplaintListScreen.tsx
+++ b/apps/mobile/src/screens/complaints/ComplaintListScreen.tsx
@@ -177,7 +177,7 @@ export function ComplaintListScreen({ route, navigation }: Props) {
     )
   }
 
-  if (isLoading) return <LoadingSpinner fullScreen />
+  if (isLoading && complaints.length === 0) return <LoadingSpinner fullScreen />
 
   return (
     <ScreenWrapper scroll={false} style={styles.wrapper}>

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -415,7 +415,7 @@ export function DashboardScreen({ route, navigation }: Props) {
 
   const hasAnyAction = actions.length > 0
 
-  if (isLoading) {
+  if (isLoading && !society) {
     return <LoadingSpinner fullScreen />
   }
 

--- a/apps/mobile/src/screens/society/DashboardScreen.tsx
+++ b/apps/mobile/src/screens/society/DashboardScreen.tsx
@@ -208,13 +208,20 @@ export function DashboardScreen({ route, navigation }: Props) {
 
   const loadVisitorStats = useCallback(async () => {
     if (permissions.includes('visitor.log')) {
-      const active = await getActiveVisitors(societyId)
-      setActiveCount(active.length)
       const today = new Date().toISOString().split('T')[0]
-      const todayEntries = await getEntryLog(societyId, { date: today })
-      setTodayCount(todayEntries.length)
-      const pending = await getEntryLog(societyId, { status: 'PENDING' })
-      setPendingCount(pending.length)
+      try {
+        const [active, todayEntries, pendingEntries] =
+          await Promise.all([
+            getActiveVisitors(societyId),
+            getEntryLog(societyId, { date: today }),
+            getEntryLog(societyId, { status: 'PENDING' }),
+          ])
+        setActiveCount(active.length)
+        setTodayCount(todayEntries.length)
+        setPendingCount(pendingEntries.length)
+      } catch {
+        // non-critical — stats fail silently
+      }
     }
     if (permissions.includes('visitor.approve')) {
       try {
@@ -230,7 +237,8 @@ export function DashboardScreen({ route, navigation }: Props) {
   useEffect(() => {
     load()
     loadVisitorStats()
-  }, [load, loadVisitorStats])
+    loadNotificationBadge()
+  }, [load, loadVisitorStats, loadNotificationBadge])
 
   const onRefresh = useCallback(async () => {
     await Promise.all([load(), loadUser(), loadVisitorStats(), loadNotificationBadge()])


### PR DESCRIPTION
## What's in this PR

### Performance Fixes
- Parallelize visitor stats API calls on dashboard
  (3 sequential calls → Promise.all, 3x faster)
- Load notification badge on initial mount
  (was only loading on re-focus, badge showed 0 initially)
- Prevent full-screen spinner flash on re-focus:
  ComplaintList, AnnouncementsList, Dashboard
  now only show full-screen spinner on first load
  when no data exists — subsequent loads refresh silently

### Result
- Dashboard stats load ~3x faster for gatekeepers
- Navigating back to complaints/announcements no longer
  shows white screen flash
- Bell badge count correct on first load
- Pull-to-refresh on dashboard no longer flashes white

### Tests
310 passing