### PR TITLE
feat: redesign welcome skyline with 16 SVG buildings

### DIFF
--- a/apps/mobile/src/screens/auth/WelcomeScreen.tsx
+++ b/apps/mobile/src/screens/auth/WelcomeScreen.tsx
@@ -1,5 +1,15 @@
 import React, { useEffect, useRef } from 'react'
-import { View, Text, Image, Pressable, StyleSheet, StatusBar, Dimensions, Animated } from 'react-native'
+import {
+  View,
+  Text,
+  Image,
+  Pressable,
+  StyleSheet,
+  StatusBar,
+  Dimensions,
+  Animated,
+} from 'react-native'
+import Svg, { Rect, Line, Path, Polyline } from 'react-native-svg'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { LinearGradient } from 'expo-linear-gradient'
 import { Ionicons } from '@expo/vector-icons'
@@ -9,37 +19,388 @@ import { AuthStackParamList } from '../../navigation/AuthNavigator'
 
 type Props = NativeStackScreenProps<AuthStackParamList, 'Welcome'>
 
-const { width } = Dimensions.get('window');
-const SLATE_DEEP = '#2f3e4e';
-const SLATE_LIGHT = '#42576e';
-const PLATINUM = 'rgba(255,255,255,0.85)';
+const { width } = Dimensions.get('window')
+const SLATE_DEEP = '#2f3e4e'
+const SLATE_LIGHT = '#42576e'
+const PLATINUM = 'rgba(255,255,255,0.85)'
+
+// SVG building palette
+const S = 'rgba(255,255,255,0.25)'   // structure strokes
+const F = 'rgba(255,255,255,0.13)'   // floor divider lines
+const W = 'rgba(220,228,238,0.80)'   // lit window
+const D = 'rgba(220,228,238,0.07)'   // dim window
 
 const FEATURES: React.ComponentProps<typeof Ionicons>['name'][] = [
   'business-outline', 'people-outline', 'warning-outline',
-  'notifications-outline', 'megaphone-outline', 'shield-checkmark-outline'
+  'notifications-outline', 'megaphone-outline', 'shield-checkmark-outline',
 ]
+
+// ─── Window helper ─────────────────────────────────────────────────────────────
+// Deterministic lit state — no Math.random() in render, no flicker on re-render
+function Win({ x, y, w = 4, h = 3, lit }: {
+  x: number; y: number; w?: number; h?: number; lit: boolean
+}) {
+  return <Rect x={x} y={y} width={w} height={h} fill={lit ? W : D} />
+}
+
+// ─── 16 SVG building components ───────────────────────────────────────────────
+// All share height=68 with flex-end bottom-alignment in the skyline row.
+// Widths: 18+42+12+46+20+38+14+50+14+40+24+40+34+28+30+38 = 488px
+// Gaps: 15 × 14 = 210px, trailing gap 14px → SCROLL_WIDTH = 712
+
+function ClockTower() {
+  const fh = 48 / 6
+  return (
+    <Svg width={18} height={68}>
+      <Line x1={9} y1={0} x2={9} y2={5} stroke={S} strokeWidth={0.7} />
+      <Polyline points="4,9 9,4 14,9" fill="none" stroke={S} strokeWidth={0.7} />
+      <Rect x={3} y={9} width={12} height={11} fill="none" stroke={S} strokeWidth={0.7} />
+      <Polyline points="5,20 5,15 9,11 13,15 13,20" fill="none" stroke={F} strokeWidth={0.5} />
+      <Rect x={5} y={20} width={8} height={48} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(5)].map((_, i) => (
+        <Line key={i} x1={5} y1={20 + (i + 1) * fh} x2={13} y2={20 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {[true, false, true, true, false, true].map((l, i) => (
+        <Win key={i} x={7} y={22 + i * fh} w={3} h={3} lit={l} />
+      ))}
+    </Svg>
+  )
+}
+
+function LargeComplex() {
+  const fh = 56 / 5
+  const cols = [
+    [true, false, true, true, true],
+    [true, true, false, true, false],
+    [false, true, true, false, true],
+    [true, false, true, true, false],
+  ]
+  return (
+    <Svg width={42} height={68}>
+      <Rect x={1} y={12} width={40} height={56} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(4)].map((_, i) => (
+        <Line key={i} x1={1} y1={12 + (i + 1) * fh} x2={41} y2={12 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {[4, 13, 22, 31].map((cx, ci) =>
+        cols[ci].map((l, ri) => (
+          <Win key={`${ci}-${ri}`} x={cx} y={12 + ri * fh + 2} w={5} h={4} lit={l} />
+        ))
+      )}
+    </Svg>
+  )
+}
+
+function SoloSpire() {
+  const fh = 66 / 11
+  const lit = [true, false, true, true, false, true, true, false, true, true, false]
+  return (
+    <Svg width={12} height={68}>
+      <Line x1={6} y1={0} x2={6} y2={2} stroke={S} strokeWidth={0.6} />
+      <Rect x={1} y={2} width={10} height={66} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(10)].map((_, i) => (
+        <Line key={i} x1={1} y1={2 + (i + 1) * fh} x2={11} y2={2 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {lit.map((l, i) => <Win key={i} x={4} y={2 + i * fh + 1.5} w={3} h={2} lit={l} />)}
+    </Svg>
+  )
+}
+
+function LowRise() {
+  const fh = 24 / 3
+  const cols = [
+    [true, true, false],
+    [false, true, true],
+    [true, false, true],
+    [true, true, false],
+  ]
+  return (
+    <Svg width={46} height={68}>
+      <Rect x={6} y={40} width={5} height={4} fill="none" stroke="rgba(255,255,255,0.18)" strokeWidth={0.5} />
+      <Rect x={20} y={39} width={8} height={5} fill="none" stroke="rgba(255,255,255,0.18)" strokeWidth={0.5} />
+      <Rect x={34} y={40} width={5} height={4} fill="none" stroke="rgba(255,255,255,0.18)" strokeWidth={0.5} />
+      <Rect x={1} y={44} width={44} height={24} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(2)].map((_, i) => (
+        <Line key={i} x1={1} y1={44 + (i + 1) * fh} x2={45} y2={44 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {[5, 16, 27, 38].map((cx, ci) =>
+        cols[ci].map((l, ri) => (
+          <Win key={`${ci}-${ri}`} x={cx} y={44 + ri * fh + 2} w={5} h={4} lit={l} />
+        ))
+      )}
+    </Svg>
+  )
+}
+
+function Tower1() {
+  const fh = 63 / 8
+  const lc = [true, true, false, true, true, false, true, true]
+  const rc = [false, true, true, false, true, true, false, true]
+  return (
+    <Svg width={20} height={68}>
+      <Rect x={1} y={5} width={18} height={63} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(7)].map((_, i) => (
+        <Line key={i} x1={1} y1={5 + (i + 1) * fh} x2={19} y2={5 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {lc.map((l, i) => <Win key={`l${i}`} x={3} y={5 + i * fh + 2} lit={l} />)}
+      {rc.map((l, i) => <Win key={`r${i}`} x={13} y={5 + i * fh + 2} lit={l} />)}
+    </Svg>
+  )
+}
+
+function DomeCrown() {
+  const fh = 32 / 3
+  const lc = [true, false, true]
+  const rc = [true, true, false]
+  return (
+    <Svg width={38} height={68}>
+      <Path d="M 1,36 A 18,22 0 0 1 37,36" fill="none" stroke={S} strokeWidth={0.8} />
+      <Line x1={19} y1={14} x2={19} y2={36} stroke={F} strokeWidth={0.5} />
+      <Win x={5} y={24} w={6} h={5} lit={true} />
+      <Win x={27} y={24} w={6} h={5} lit={true} />
+      <Rect x={1} y={36} width={36} height={32} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(2)].map((_, i) => (
+        <Line key={i} x1={1} y1={36 + (i + 1) * fh} x2={37} y2={36 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {lc.map((l, i) => <Win key={`l${i}`} x={4} y={38 + i * fh} w={5} h={4} lit={l} />)}
+      {rc.map((l, i) => <Win key={`r${i}`} x={29} y={38 + i * fh} w={5} h={4} lit={l} />)}
+    </Svg>
+  )
+}
+
+function NarrowTower() {
+  const fh = 62 / 6
+  const cc = [true, true, false, true, false, true]
+  return (
+    <Svg width={14} height={68}>
+      <Rect x={1} y={6} width={12} height={62} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(5)].map((_, i) => (
+        <Line key={i} x1={1} y1={6 + (i + 1) * fh} x2={13} y2={6 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {cc.map((l, i) => <Win key={i} x={5} y={6 + i * fh + 2} w={3} h={3} lit={l} />)}
+    </Svg>
+  )
+}
+
+function ClubHouse() {
+  const fh = 26 / 2
+  const wins: boolean[][] = [[true, true], [false, true], [true, false]]
+  return (
+    <Svg width={50} height={68}>
+      <Rect x={0} y={38} width={50} height={4} fill="none" stroke={S} strokeWidth={0.7} />
+      <Rect x={0} y={42} width={50} height={26} fill="none" stroke={S} strokeWidth={0.7} />
+      <Line x1={0} y1={42 + fh} x2={50} y2={42 + fh} stroke={F} strokeWidth={0.4} />
+      {[5, 20, 35].map((cx, ci) =>
+        wins[ci].map((l, ri) => (
+          <Win key={`${ci}-${ri}`} x={cx} y={42 + ri * fh + 3} w={10} h={8} lit={l} />
+        ))
+      )}
+    </Svg>
+  )
+}
+
+function Skyscraper() {
+  const fh = 67 / 10
+  const lc = [true, false, true, true, false, true, true, false, true, false]
+  const rc = [false, true, true, false, true, false, true, true, false, true]
+  return (
+    <Svg width={14} height={68}>
+      <Rect x={1} y={1} width={12} height={67} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(9)].map((_, i) => (
+        <Line key={i} x1={1} y1={1 + (i + 1) * fh} x2={13} y2={1 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {lc.map((l, i) => <Win key={`l${i}`} x={2} y={1 + i * fh + 1.5} w={3} h={2} lit={l} />)}
+      {rc.map((l, i) => <Win key={`r${i}`} x={9} y={1 + i * fh + 1.5} w={3} h={2} lit={l} />)}
+    </Svg>
+  )
+}
+
+function TaperedTower() {
+  return (
+    <Svg width={40} height={68}>
+      <Line x1={20} y1={3} x2={20} y2={10} stroke={S} strokeWidth={0.6} />
+      <Rect x={12} y={10} width={16} height={14} fill="none" stroke={S} strokeWidth={0.7} />
+      <Line x1={12} y1={17} x2={28} y2={17} stroke={F} strokeWidth={0.4} />
+      <Win x={14} y={12} w={4} h={3} lit={true} />
+      <Win x={22} y={12} w={4} h={3} lit={false} />
+      <Win x={14} y={19} w={4} h={3} lit={true} />
+      <Win x={22} y={19} w={4} h={3} lit={true} />
+      <Rect x={6} y={24} width={28} height={20} fill="none" stroke={S} strokeWidth={0.7} />
+      <Line x1={6} y1={34} x2={34} y2={34} stroke={F} strokeWidth={0.4} />
+      <Win x={9} y={27} w={5} h={4} lit={true} />
+      <Win x={17} y={27} w={5} h={4} lit={false} />
+      <Win x={25} y={27} w={5} h={4} lit={true} />
+      <Win x={9} y={37} w={5} h={4} lit={false} />
+      <Win x={17} y={37} w={5} h={4} lit={true} />
+      <Win x={25} y={37} w={5} h={4} lit={true} />
+      <Rect x={0} y={44} width={40} height={24} fill="none" stroke={S} strokeWidth={0.7} />
+      <Line x1={0} y1={56} x2={40} y2={56} stroke={F} strokeWidth={0.4} />
+      <Win x={4} y={47} w={5} h={4} lit={true} />
+      <Win x={16} y={47} w={5} h={4} lit={false} />
+      <Win x={28} y={47} w={5} h={4} lit={true} />
+      <Win x={4} y={59} w={5} h={4} lit={false} />
+      <Win x={16} y={59} w={5} h={4} lit={true} />
+      <Win x={28} y={59} w={5} h={4} lit={true} />
+    </Svg>
+  )
+}
+
+function CondoTower() {
+  const ufh = 16 / 2
+  const mfh = 44 / 4
+  const lc = [true, true, false, true]
+  const rc = [false, true, true, false]
+  return (
+    <Svg width={24} height={68}>
+      <Rect x={4} y={8} width={16} height={16} fill="none" stroke={S} strokeWidth={0.7} />
+      <Line x1={4} y1={8 + ufh} x2={20} y2={8 + ufh} stroke={F} strokeWidth={0.4} />
+      <Win x={9} y={8 + 2} w={5} h={4} lit={true} />
+      <Win x={9} y={8 + ufh + 2} w={5} h={4} lit={false} />
+      <Rect x={0} y={24} width={24} height={44} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(3)].map((_, i) => (
+        <Line key={i} x1={0} y1={24 + (i + 1) * mfh} x2={24} y2={24 + (i + 1) * mfh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {lc.map((l, i) => <Win key={`l${i}`} x={2} y={24 + i * mfh + 2} w={4} h={4} lit={l} />)}
+      {rc.map((l, i) => <Win key={`r${i}`} x={18} y={24 + i * mfh + 2} w={4} h={4} lit={l} />)}
+    </Svg>
+  )
+}
+
+function Villa() {
+  return (
+    <Svg width={40} height={68}>
+      <Polyline points="20,33 0,46 40,46" fill="none" stroke={S} strokeWidth={0.8} />
+      <Rect x={3} y={46} width={34} height={22} fill="none" stroke={S} strokeWidth={0.7} />
+      <Rect x={15} y={57} width={10} height={11} fill="none" stroke="rgba(255,255,255,0.2)" strokeWidth={0.6} />
+      <Win x={6} y={50} w={8} h={6} lit={true} />
+      <Win x={26} y={50} w={8} h={6} lit={true} />
+    </Svg>
+  )
+}
+
+function TwinTower() {
+  const lfh = 65 / 8
+  const rfh = 53 / 6
+  const lc = [true, true, false, true, false, true, true, false]
+  const rc = [true, false, true, true, false, true]
+  return (
+    <Svg width={34} height={68}>
+      <Rect x={0} y={3} width={15} height={65} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(7)].map((_, i) => (
+        <Line key={i} x1={0} y1={3 + (i + 1) * lfh} x2={15} y2={3 + (i + 1) * lfh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {lc.map((l, i) => <Win key={`l${i}`} x={5} y={3 + i * lfh + 2} w={4} h={3} lit={l} />)}
+      <Rect x={15} y={26} width={4} height={3} fill="none" stroke="rgba(255,255,255,0.18)" strokeWidth={0.4} />
+      <Rect x={19} y={15} width={15} height={53} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(5)].map((_, i) => (
+        <Line key={i} x1={19} y1={15 + (i + 1) * rfh} x2={34} y2={15 + (i + 1) * rfh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {rc.map((l, i) => <Win key={`r${i}`} x={24} y={15 + i * rfh + 2} w={4} h={3} lit={l} />)}
+    </Svg>
+  )
+}
+
+function FlatTop() {
+  const fh = 41 / 4
+  const lc = [true, false, true, true]
+  const rc = [false, true, false, true]
+  return (
+    <Svg width={28} height={68}>
+      <Rect x={2} y={23} width={24} height={4} fill="none" stroke={S} strokeWidth={0.7} />
+      <Rect x={0} y={27} width={28} height={41} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(3)].map((_, i) => (
+        <Line key={i} x1={0} y1={27 + (i + 1) * fh} x2={28} y2={27 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {lc.map((l, i) => <Win key={`l${i}`} x={4} y={27 + i * fh + 2} w={5} h={4} lit={l} />)}
+      {rc.map((l, i) => <Win key={`r${i}`} x={19} y={27 + i * fh + 2} w={5} h={4} lit={l} />)}
+    </Svg>
+  )
+}
+
+function ArchwayBlock() {
+  const fh = 47 / 5
+  const lc = [true, false, true, true, false]
+  const rc = [false, true, true, false, true]
+  return (
+    <Svg width={30} height={68}>
+      <Rect x={0} y={5} width={30} height={3} fill="none" stroke="rgba(255,255,255,0.16)" strokeWidth={0.5} />
+      <Path d="M 1,55 L 1,8 L 29,8 L 29,55" fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(4)].map((_, i) => (
+        <Line key={i} x1={1} y1={8 + (i + 1) * fh} x2={29} y2={8 + (i + 1) * fh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {lc.map((l, i) => <Win key={`l${i}`} x={3} y={10 + i * fh} w={4} h={4} lit={l} />)}
+      {rc.map((l, i) => <Win key={`r${i}`} x={23} y={10 + i * fh} w={4} h={4} lit={l} />)}
+      <Path d="M 8,55 A 7,8 0 0 1 22,55" fill="none" stroke={S} strokeWidth={0.7} />
+      <Path d="M 1,55 L 1,68 L 8,68 L 8,55" fill="none" stroke={S} strokeWidth={0.7} />
+      <Path d="M 22,55 L 22,68 L 29,68 L 29,55" fill="none" stroke={S} strokeWidth={0.7} />
+    </Svg>
+  )
+}
+
+function SteppedBlock() {
+  const lfh = 58 / 6
+  const rfh = 42 / 4
+  const lc = [true, false, true, true, false, true]
+  const rc1 = [true, true, false, true]
+  const rc2 = [false, true, true, false]
+  return (
+    <Svg width={38} height={68}>
+      <Rect x={0} y={10} width={18} height={58} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(5)].map((_, i) => (
+        <Line key={i} x1={0} y1={10 + (i + 1) * lfh} x2={18} y2={10 + (i + 1) * lfh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {lc.map((l, i) => <Win key={`l${i}`} x={6} y={10 + i * lfh + 2} w={4} h={3} lit={l} />)}
+      <Rect x={18} y={26} width={20} height={42} fill="none" stroke={S} strokeWidth={0.7} />
+      {[...Array(3)].map((_, i) => (
+        <Line key={i} x1={18} y1={26 + (i + 1) * rfh} x2={38} y2={26 + (i + 1) * rfh} stroke={F} strokeWidth={0.4} />
+      ))}
+      {rc1.map((l, i) => <Win key={`r1${i}`} x={21} y={26 + i * rfh + 2} w={4} h={3} lit={l} />)}
+      {rc2.map((l, i) => <Win key={`r2${i}`} x={30} y={26 + i * rfh + 2} w={4} h={3} lit={l} />)}
+    </Svg>
+  )
+}
+
+// Skyline order: alternates tall/short, narrow/wide for a varied silhouette
+const BUILDINGS = [
+  ClockTower,    // 18w — tall Gothic spire
+  LargeComplex,  // 42w — medium wide slab
+  SoloSpire,     // 12w — thin needle
+  LowRise,       // 46w — very short 3-storey (BIG height contrast)
+  Tower1,        // 20w — standard tall
+  DomeCrown,     // 38w — dome arch top
+  NarrowTower,   // 14w — slim column
+  ClubHouse,     // 50w — widest + shortest
+  Skyscraper,    // 14w — very tall narrow
+  TaperedTower,  // 40w — stepped pyramid tiers
+  CondoTower,    // 24w — setback upper block
+  Villa,         // 40w — pitched roof, low
+  TwinTower,     // 34w — two-tower complex
+  FlatTop,       // 28w — cornice cap
+  ArchwayBlock,  // 30w — vaulted entrance arch
+  SteppedBlock,  // 38w — two staggered volumes
+] as const
+
+// Total one-copy width: 488px buildings + 15×14px gaps + 14px trailing = 712px
+const SCROLL_WIDTH = 712
+
+// ─── Screen ───────────────────────────────────────────────────────────────────
 
 export function WelcomeScreen({ navigation }: Props) {
   const insets = useSafeAreaInsets()
   const [fontsLoaded] = useFonts({ Montserrat_300Light, Montserrat_600SemiBold })
 
-  // Master driver: 0 to 1
   const waveAnim = useRef(new Animated.Value(0)).current
   const scrollAnim = useRef(new Animated.Value(0)).current
   const entranceAnim = useRef(new Animated.Value(0)).current
 
-  // Assign a unique starting offset to each icon
   const offsets = React.useMemo(() => FEATURES.map(() => Math.random()), [])
 
   useEffect(() => {
-    // 1: Blueprint Build-In (One-time entrance)
     Animated.timing(entranceAnim, {
       toValue: 1,
-      duration: 2500,
+      duration: 2800,
       useNativeDriver: true,
     }).start()
 
-    // 2: Master loop for the 8-second shimmer
     Animated.loop(
       Animated.timing(waveAnim, {
         toValue: 1,
@@ -48,223 +409,66 @@ export function WelcomeScreen({ navigation }: Props) {
       })
     ).start()
 
-    // 4: Slow, infinite scroll for the architecture (40 seconds per loop)
+    // useNativeDriver: true — translateX is numeric, runs on UI thread
     Animated.loop(
       Animated.timing(scrollAnim, {
         toValue: 1,
-        duration: 40000,
-        useNativeDriver: false, // Using false because we need to calculate width-based translate
+        duration: 50000,
+        useNativeDriver: true,
       })
     ).start()
   }, [])
 
   if (!fontsLoaded) return null
 
-  const renderBuildings = (offsetIndex: number = 0) => {
-    // Strictly theme-safe colors
-    const LIGHTS = [
-      PLATINUM + '70', // Platinum (Active)
-      'rgba(255, 255, 255, 0.4)', // Pure White (High Focus)
-      SLATE_LIGHT + '60', // Slate Light (Reflective)
-    ];
+  const N = BUILDINGS.length
 
-    const getBuildStyle = (index: number) => {
-      const start = index * 0.1;
-      const end = Math.min(start + 0.3, 1);
-      
-      return {
-        opacity: entranceAnim.interpolate({
-          inputRange: [start, end],
-          outputRange: [0, 1],
-          extrapolate: 'clamp'
-        }),
-        transform: [
-          {
-            scaleY: entranceAnim.interpolate({
-              inputRange: [start, end],
-              outputRange: [0, 1],
-              extrapolate: 'clamp'
-            })
-          },
-          {
-            translateY: entranceAnim.interpolate({
-              inputRange: [start, end],
-              outputRange: [20, 0], // Subtle rise from the ground
-              extrapolate: 'clamp'
-            })
-          }
-        ]
-      };
-    };
+  function renderBuildings() {
+    return BUILDINGS.map((Building, i) => {
+      // Entrance: buildings rise and fade in from ground, staggered
+      const start = i / N
+      const end = Math.min(start + 0.22, 1)
 
-    return (
-      <>
-        {/* 1: Modern Residential Tower */}
-        <Animated.View style={getBuildStyle(0)}>
-          <Animated.View style={[styles.archBuilding, { height: 60, width: 26, opacity: waveAnim.interpolate({ inputRange: [0, 0.1, 0.25, 1], outputRange: [0.3, 0.85, 0.3, 0.3] }) }]}>
-            {[0, 1, 2, 3, 4, 5, 6, 7].map(i => (
-              <View key={i} style={{ position: 'absolute', top: `${i * 12}%`, left: '8%', width: '84%', height: '11%', borderTopWidth: 0.7, borderColor: 'rgba(255,255,255,0.4)' }} />
-            ))}
-            {[0, 1, 2, 3, 4, 5, 6, 7].map(i => (
-              <View key={`w${i}`} style={{ position: 'absolute', top: `${i * 12 + 2}%`, left: '12%', width: 5, height: 3, backgroundColor: Math.random() > 0.4 ? LIGHTS[Math.floor(Math.random() * 3)] : 'transparent', borderRadius: 1 }} />
-            ))}
-            {[0, 1, 2, 3, 4, 5, 6, 7].map(i => (
-              <View key={`w2${i}`} style={{ position: 'absolute', top: `${i * 12 + 2}%`, right: '12%', width: 5, height: 3, backgroundColor: Math.random() > 0.4 ? LIGHTS[Math.floor(Math.random() * 3)] : 'transparent', borderRadius: 1 }} />
-            ))}
+      const entranceOpacity = entranceAnim.interpolate({
+        inputRange: [start, end],
+        outputRange: [0, 1],
+        extrapolate: 'clamp',
+      })
+      const entranceScaleY = entranceAnim.interpolate({
+        inputRange: [start, end],
+        outputRange: [0.05, 1],
+        extrapolate: 'clamp',
+      })
+      const entranceTranslateY = entranceAnim.interpolate({
+        inputRange: [start, end],
+        outputRange: [24, 0],
+        extrapolate: 'clamp',
+      })
+
+      // Wave shimmer: sequential brightness pulse across the skyline
+      const peak = (i + 0.5) / N
+      const hw = 0.38 / N
+      const waveOpacity = waveAnim.interpolate({
+        inputRange: [Math.max(0.001, peak - hw), peak, Math.min(0.999, peak + hw)],
+        outputRange: [0.38, 0.92, 0.38],
+        extrapolate: 'clamp',
+      })
+
+      return (
+        <Animated.View
+          key={i}
+          style={{
+            opacity: entranceOpacity,
+            transform: [{ scaleY: entranceScaleY }, { translateY: entranceTranslateY }],
+          }}
+        >
+          <Animated.View style={{ opacity: waveOpacity }}>
+            <Building />
           </Animated.View>
         </Animated.View>
-
-        {/* 2: Contemporary Apartment Block */}
-        <Animated.View style={getBuildStyle(1)}>
-          <Animated.View style={[styles.archBuilding, { height: 50, width: 38, opacity: waveAnim.interpolate({ inputRange: [0, 0.2, 0.35, 1], outputRange: [0.3, 0.85, 0.3, 0.3] }) }]}>
-            {[0, 1, 2, 3, 4, 5].map(i => (
-              <View key={i} style={{ position: 'absolute', top: `${i * 16.67}%`, left: 0, right: 0, height: 0.6, backgroundColor: 'rgba(255,255,255,0.35)' }} />
-            ))}
-            {Array.from({ length: 6 }).map((_, row) =>
-              Array.from({ length: 3 }).map((_, col) => (
-                <View
-                  key={`${row}-${col}`}
-                  style={{
-                    position: 'absolute',
-                    top: `${row * 16.67 + 3}%`,
-                    left: `${col * 32 + 5}%`,
-                    width: 6,
-                    height: 4,
-                    backgroundColor: Math.random() > 0.5 ? LIGHTS[Math.floor(Math.random() * 3)] : 'transparent',
-                    borderRadius: 0.5,
-                  }}
-                />
-              ))
-            )}
-          </Animated.View>
-        </Animated.View>
-
-        {/* 3: Classic Villa */}
-        <Animated.View style={getBuildStyle(2)}>
-          <Animated.View style={[styles.archBuilding, { height: 35, width: 44, opacity: waveAnim.interpolate({ inputRange: [0, 0.3, 0.45, 1], outputRange: [0.3, 0.85, 0.3, 0.3] }) }]}>
-            <View style={{ position: 'absolute', top: -8, left: -2, width: '55%', height: 1.5, backgroundColor: 'rgba(255,255,255,0.6)', transform: [{ rotate: '-20deg' }] }} />
-            <View style={{ position: 'absolute', top: -8, right: -2, width: '55%', height: 1.5, backgroundColor: 'rgba(255,255,255,0.6)', transform: [{ rotate: '20deg' }] }} />
-            <View style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, borderWidth: 0.8, borderColor: 'rgba(255,255,255,0.45)' }} />
-            <View style={{ position: 'absolute', bottom: 0, left: '50%', marginLeft: -4, width: 8, height: 14, borderWidth: 0.7, borderColor: 'rgba(255,255,255,0.4)', borderBottomWidth: 0 }} />
-            <View style={{ position: 'absolute', top: 8, left: 6, width: 8, height: 6, borderWidth: 0.6, borderColor: 'rgba(255,255,255,0.4)', backgroundColor: Math.random() > 0.3 ? LIGHTS[1] : 'transparent' }} />
-            <View style={{ position: 'absolute', top: 8, right: 6, width: 8, height: 6, borderWidth: 0.6, borderColor: 'rgba(255,255,255,0.4)', backgroundColor: Math.random() > 0.3 ? LIGHTS[1] : 'transparent' }} />
-          </Animated.View>
-        </Animated.View>
-
-        {/* 4: Skyscraper Tower */}
-        <Animated.View style={getBuildStyle(3)}>
-          <Animated.View style={[styles.archBuilding, { height: 58, width: 18, opacity: waveAnim.interpolate({ inputRange: [0, 0.4, 0.55, 1], outputRange: [0.3, 0.85, 0.3, 0.3] }) }]}>
-            {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => (
-              <View key={i} style={{ position: 'absolute', top: `${i * 10}%`, left: 0, right: 0, height: 0.7, backgroundColor: 'rgba(255,255,255,0.4)' }} />
-            ))}
-            {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => (
-              <View key={`l${i}`} style={{ position: 'absolute', top: `${i * 10 + 2}%`, left: '15%', width: 4, height: 3, backgroundColor: Math.random() > 0.4 ? LIGHTS[0] : 'transparent', borderRadius: 0.5 }} />
-            ))}
-            {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9].map(i => (
-              <View key={`r${i}`} style={{ position: 'absolute', top: `${i * 10 + 2}%`, right: '15%', width: 4, height: 3, backgroundColor: Math.random() > 0.4 ? LIGHTS[0] : 'transparent', borderRadius: 0.5 }} />
-            ))}
-          </Animated.View>
-        </Animated.View>
-
-        {/* 5: Modern Flat-Top */}
-        <Animated.View style={getBuildStyle(4)}>
-          <Animated.View style={[styles.archBuilding, { height: 40, width: 32, opacity: waveAnim.interpolate({ inputRange: [0, 0.5, 0.65, 1], outputRange: [0.3, 0.85, 0.3, 0.3] }) }]}>
-            <View style={{ position: 'absolute', top: -3, left: '10%', right: '10%', height: 2, backgroundColor: 'rgba(255,255,255,0.4)' }} />
-            {[0, 1, 2, 3].map(i => (
-              <View key={i} style={{ position: 'absolute', top: `${i * 25}%`, left: 0, right: 0, height: 0.7, backgroundColor: 'rgba(255,255,255,0.35)' }} />
-            ))}
-            {Array.from({ length: 4 }).map((_, row) =>
-              Array.from({ length: 2 }).map((_, col) => (
-                <View
-                  key={`${row}-${col}`}
-                  style={{
-                    position: 'absolute',
-                    top: `${row * 25 + 4}%`,
-                    left: `${col === 0 ? 10 : 65}%`,
-                    width: 7,
-                    height: 5,
-                    backgroundColor: Math.random() > 0.5 ? LIGHTS[Math.floor(Math.random() * 3)] : 'transparent',
-                    borderRadius: 0.5,
-                  }}
-                />
-              ))
-            )}
-          </Animated.View>
-        </Animated.View>
-
-        {/* 6: Twin Tower Complex */}
-        <Animated.View style={getBuildStyle(5)}>
-          <Animated.View style={{ flexDirection: 'row', alignItems: 'flex-end', height: 60, opacity: waveAnim.interpolate({ inputRange: [0, 0.6, 0.75, 1], outputRange: [0.3, 0.85, 0.3, 0.3] }) }}>
-            <View style={[styles.archBuilding, { height: 55, width: 14, borderBottomWidth: 0.8 }]}>
-              <View style={{ position: 'absolute', top: -4, left: 0, width: 8, height: 1, backgroundColor: 'rgba(255,255,255,0.5)' }} />
-              {[0, 1, 2, 3, 4].map(i => (
-                <View key={i} style={{ position: 'absolute', top: `${i * 18 + 8}%`, left: 3, width: 3, height: 4, backgroundColor: i % 2 === 0 ? 'rgba(255,255,255,0.15)' : 'transparent', borderRadius: 0.5 }} />
-              ))}
-            </View>
-            <View style={[styles.archBuilding, { height: 38, width: 18, borderLeftWidth: 0, borderBottomWidth: 0.8 }]}>
-              <View style={{ position: 'absolute', top: '40%', left: -4, width: 4, height: 2, backgroundColor: 'rgba(255,255,255,0.3)', zIndex: 10 }} />
-              {[0, 1, 2].map(i => (
-                <View key={i} style={{ position: 'absolute', top: `${i * 28 + 10}%`, right: 3, width: 8, height: 1.5, backgroundColor: 'rgba(255,255,255,0.25)' }} />
-              ))}
-              <View style={{ position: 'absolute', bottom: 0, right: 4, width: 6, height: 8, borderWidth: 0.6, borderColor: 'rgba(255,255,255,0.4)', borderBottomWidth: 0 }} />
-            </View>
-          </Animated.View>
-        </Animated.View>
-
-        {/* 7: Large Residential Complex */}
-        <Animated.View style={getBuildStyle(6)}>
-          <Animated.View style={[styles.archBuilding, { height: 48, width: 46, opacity: waveAnim.interpolate({ inputRange: [0, 0.7, 0.85, 1], outputRange: [0.3, 0.85, 0.3, 0.3] }) }]}>
-            <View style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 1, backgroundColor: 'rgba(255,255,255,0.4)' }} />
-            {[0, 1, 2, 3, 4].map(i => (
-              <View key={i} style={{ position: 'absolute', top: `${i * 20}%`, left: 0, right: 0, height: 0.7, backgroundColor: 'rgba(255,255,255,0.35)' }} />
-            ))}
-            {Array.from({ length: 5 }).map((_, row) =>
-              Array.from({ length: 4 }).map((_, col) => (
-                <View
-                  key={`${row}-${col}`}
-                  style={{
-                    position: 'absolute',
-                    top: `${row * 20 + 2.5}%`,
-                    left: `${col * 23 + 4}%`,
-                    width: 5,
-                    height: 3.5,
-                    backgroundColor: Math.random() > 0.6 ? LIGHTS[Math.floor(Math.random() * 3)] : 'transparent',
-                    borderRadius: 0.4,
-                  }}
-                />
-              ))
-            )}
-          </Animated.View>
-        </Animated.View>
-
-        {/* 8: Corner Building */}
-        <Animated.View style={getBuildStyle(7)}>
-          <Animated.View style={[styles.archBuilding, { height: 42, width: 28, opacity: waveAnim.interpolate({ inputRange: [0, 0.8, 0.95, 1], outputRange: [0.3, 0.85, 0.3, 0.3] }) }]}>
-            <View style={{ position: 'absolute', top: -4, left: '5%', right: '5%', height: 2.5, backgroundColor: 'rgba(255,255,255,0.45)' }} />
-            {[0, 1, 2, 3, 4].map(i => (
-              <View key={i} style={{ position: 'absolute', top: `${i * 20}%`, left: 0, right: 0, height: 0.8, backgroundColor: 'rgba(255,255,255,0.4)' }} />
-            ))}
-            {Array.from({ length: 5 }).map((_, row) =>
-              Array.from({ length: 2 }).map((_, col) => (
-                <View
-                  key={`${row}-${col}`}
-                  style={{
-                    position: 'absolute',
-                    top: `${row * 20 + 3}%`,
-                    left: `${col === 0 ? 12 : 65}%`,
-                    width: 8,
-                    height: 5,
-                    backgroundColor: Math.random() > 0.5 ? LIGHTS[Math.floor(Math.random() * 3)] : 'transparent',
-                    borderRadius: 0.5,
-                  }}
-                />
-              ))
-            )}
-          </Animated.View>
-        </Animated.View>
-      </>
-    );
-  };
+      )
+    })
+  }
 
   return (
     <View style={styles.root}>
@@ -287,29 +491,22 @@ export function WelcomeScreen({ navigation }: Props) {
           <Text style={styles.tagline}>Where Societies Start Organized</Text>
         </View>
 
+        {/* Feature icon grid */}
         <View style={styles.gridContainer}>
           {FEATURES.map((icon, index) => {
-            const offset = offsets[index];
+            const offset = offsets[index]
             const opacity = waveAnim.interpolate({
               inputRange: [0, (0.5 + offset) % 1, 1],
               outputRange: [0.4, 0.7, 0.4],
-            });
-
+            })
             const scale = waveAnim.interpolate({
               inputRange: [0, (0.5 + offset) % 1, 1],
               outputRange: [1, 1.06, 1],
-            });
-
+            })
             return (
               <Animated.View
                 key={index}
-                style={[
-                  styles.iconCircle,
-                  {
-                    opacity,
-                    transform: [{ scale }]
-                  }
-                ]}
+                style={[styles.iconCircle, { opacity, transform: [{ scale }] }]}
               >
                 <Ionicons name={icon} size={20} color="rgba(255,255,255,0.8)" />
               </Animated.View>
@@ -317,16 +514,21 @@ export function WelcomeScreen({ navigation }: Props) {
           })}
         </View>
 
-        {/* ── Continuous Community Panorama ── */}
-        <View style={styles.archRowContainer}>
-          <Animated.View style={[styles.archRow, {
-            transform: [{
-              translateX: scrollAnim.interpolate({
-                inputRange: [0, 1],
-                outputRange: [0, -320] // Width of one complete set of buildings + gaps
-              })
-            }]
-          }]}>
+        {/* Scrolling skyline */}
+        <View style={styles.skylineContainer}>
+          <Animated.View
+            style={[
+              styles.skylineRow,
+              {
+                transform: [{
+                  translateX: scrollAnim.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [0, -SCROLL_WIDTH],
+                  }),
+                }],
+              },
+            ]}
+          >
             {renderBuildings()}
             {renderBuildings()}
           </Animated.View>
@@ -337,7 +539,7 @@ export function WelcomeScreen({ navigation }: Props) {
         <Pressable
           style={({ pressed }) => [
             styles.btnPrimary,
-            pressed && { backgroundColor: 'rgba(255,255,255,0.1)' }
+            pressed && { backgroundColor: 'rgba(255,255,255,0.1)' },
           ]}
           onPress={() => navigation.navigate('LoginPhone')}
         >
@@ -391,41 +593,6 @@ const styles = StyleSheet.create({
     gap: 25,
     marginBottom: 80,
   },
-  archRowContainer: {
-    width: '120%', // Slightly wider to ensure edge-to-edge coverage
-    height: 80,
-    overflow: 'hidden',
-    marginBottom: 5,
-    marginTop: 15,
-  },
-  archRow: {
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    justifyContent: 'flex-start',
-    gap: 15,
-    // Width will be handled by content
-  },
-  archBuilding: {
-    borderWidth: 0.8,
-    borderColor: 'rgba(255,255,255,0.45)', // Brighter, more defined borders
-    backgroundColor: 'rgba(255,255,255,0.03)',
-    position: 'relative',
-  },
-  buildingLine: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    width: 0.8,
-    backgroundColor: 'rgba(255,255,255,0.35)', // Crisper internal lines
-    left: '50%',
-  },
-  buildingFloor: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    height: 0.8,
-    backgroundColor: 'rgba(255,255,255,0.25)', // Brighter floor dividers
-  },
   iconCircle: {
     width: 48,
     height: 48,
@@ -435,6 +602,18 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  skylineContainer: {
+    width: '120%',
+    height: 80,
+    overflow: 'hidden',
+    marginBottom: 5,
+    marginTop: 15,
+  },
+  skylineRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 14,
   },
   bottom: {
     paddingHorizontal: 45,


### PR DESCRIPTION
Replace 8 View-based buildings with 16 SVG buildings using react-native-svg. Adds ClockTower, DomeCrown, TaperedTower and ArchwayBlock from the landing page design. Fixes Math.random() window flicker with deterministic boolean arrays, switches scroll animation to useNativeDriver:true, and corrects SCROLL_WIDTH to 712px for a seamless marquee loop.