### PR TITLE
fix: security audit sprint 2

### DIFF
--- a/apps/api/prisma/migrations/20260602102400_add_primary_owner_uniqueness/migration.sql
+++ b/apps/api/prisma/migrations/20260602102400_add_primary_owner_uniqueness/migration.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX "unique_active_primary_owner" ON "unit_ownerships" ("unitId") WHERE "isPrimary" = true AND "ownedUntil" IS NULL;
+CREATE UNIQUE INDEX "unique_active_primary_occupant" ON "unit_occupancies" ("unitId") WHERE "isPrimary" = true AND "occupiedUntil" IS NULL;

--- a/apps/api/prisma/migrations/20260602155637_add_node_code_uniqueness/migration.sql
+++ b/apps/api/prisma/migrations/20260602155637_add_node_code_uniqueness/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE UNIQUE INDEX "unique_node_code" ON "property_nodes"("orgId", "parentId", "code");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -193,6 +193,7 @@ model PropertyNode {
   visitorEntries      VisitorEntry[]     @relation("VisitorEntryUnit")
   visitorPreApprovals VisitorPreApproval[] @relation("PreApprovalUnit")
 
+  @@unique([orgId, parentId, code], name: "unique_node_code")
   @@map("property_nodes")
   @@index([orgId, parentId])
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -20,8 +20,8 @@ const app = express()
 
 app.set('trust proxy', 1)
 
-app.use(express.json({ limit: '50mb' }))
-app.use(express.urlencoded({ limit: '50mb', extended: true }))
+app.use(express.json({ limit: '10mb' }))
+app.use(express.urlencoded({ limit: '10mb', extended: true }))
 app.use(apiRateLimit)
 
 app.use('/api', testRouter)

--- a/apps/api/src/routes/announcements.ts
+++ b/apps/api/src/routes/announcements.ts
@@ -31,6 +31,8 @@ router.post(
       if (!body || !body.trim()) {
         return sendError(res, 'missing_field', 400, { field: 'body' })
       }
+      if (title.length > 200) return sendError(res, 'title_too_long', 400, { max: 200 })
+      if (body.length > 10000) return sendError(res, 'body_too_long', 400, { max: 10000 })
       if (category && !VALID_CATEGORIES.includes(category)) {
         return sendError(res, 'invalid_category', 400)
       }

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -189,22 +189,22 @@ router.post('/verify-otp', async (req: AuthRequest, res: Response) => {
     })
 
     if (invitation) {
-      // auto-accept invitation — create membership
-      await prisma.membership.create({
-        data: {
-          userId: user.id,
-          orgId: invitation.orgId,
-          roleId: invitation.roleId,
-          invitedBy: invitation.invitedBy,
-          isActive: true
-        }
-      })
-
-      // mark invitation accepted
-      await prisma.invitation.update({
-        where: { id: invitation.id },
-        data: { acceptedAt: new Date() }
-      })
+      // auto-accept invitation — membership + mark accepted atomically
+      await prisma.$transaction([
+        prisma.membership.create({
+          data: {
+            userId: user.id,
+            orgId: invitation.orgId,
+            roleId: invitation.roleId,
+            invitedBy: invitation.invitedBy,
+            isActive: true
+          }
+        }),
+        prisma.invitation.update({
+          where: { id: invitation.id },
+          data: { acceptedAt: new Date() }
+        })
+      ])
 
       // reload user with new membership
       user = await prisma.user.findUnique({

--- a/apps/api/src/routes/complaints.ts
+++ b/apps/api/src/routes/complaints.ts
@@ -29,6 +29,9 @@ router.post(
         })
       }
 
+      if (title.length > 200) return sendError(res, 'title_too_long', 400, { max: 200 })
+      if (description.length > 5000) return sendError(res, 'description_too_long', 400, { max: 5000 })
+
       const validCategories = [
         'WATER_SUPPLY', 'ELECTRICITY', 'LIFT_ELEVATOR', 'GENERATOR',
         'INTERNET_CABLE', 'PARKING', 'GARBAGE_WASTE', 'GARDEN_LANDSCAPING',

--- a/apps/api/src/routes/nodes.ts
+++ b/apps/api/src/routes/nodes.ts
@@ -145,14 +145,18 @@ router.post(
         })
       }
 
-      // 2. validate nodeType
+      // 2. validate lengths
+      if (name.length > 100) return sendError(res, 'name_too_long', 400, { max: 100 })
+      if (code.length > 20) return sendError(res, 'code_too_long', 400, { max: 20 })
+
+      // 3. validate nodeType
       if (!VALID_NODE_TYPES.includes(nodeType)) {
         return sendError(res, 'invalid_node_type', 400, {
           allowed: VALID_NODE_TYPES
         })
       }
 
-      // 3. verify membership
+      // 4. verify membership
       const membership = await prisma.membership.findFirst({
         where: {
           userId: req.user!.userId,
@@ -181,27 +185,32 @@ router.post(
       }
 
       // 6. create node
-      const node = await prisma.propertyNode.create({
-        data: {
-          orgId: id,
-          parentId,
-          nodeType,
-          name,
-          code,
-          metadata: metadata || {}
-        }
-      })
+      try {
+        const node = await prisma.propertyNode.create({
+          data: {
+            orgId: id,
+            parentId,
+            nodeType,
+            name,
+            code,
+            metadata: metadata || {}
+          }
+        })
 
-      return sendCreated(res, {
-        id: node.id,
-        orgId: node.orgId,
-        parentId: node.parentId,
-        nodeType: node.nodeType,
-        name: node.name,
-        code: node.code,
-        metadata: node.metadata,
-        createdAt: node.createdAt
-      })
+        return sendCreated(res, {
+          id: node.id,
+          orgId: node.orgId,
+          parentId: node.parentId,
+          nodeType: node.nodeType,
+          name: node.name,
+          code: node.code,
+          metadata: node.metadata,
+          createdAt: node.createdAt
+        })
+      } catch (e: any) {
+        if (e.code === 'P2002') return sendError(res, 'duplicate_code', 409, { message: `Code '${code}' already exists under this parent` })
+        throw e
+      }
 
     } catch (error) {
       console.error('POST /societies/:id/nodes error:', error)
@@ -362,7 +371,11 @@ router.patch(
       const node = await getNodeInOrg(nodeId, id)
       if (!node) return sendNotFound(res, 'node_not_found')
 
-      // 3. if changing code — check duplicate under same parent
+      // 3. validate lengths if provided
+      if (name && name.length > 100) return sendError(res, 'name_too_long', 400, { max: 100 })
+      if (code && code.length > 20) return sendError(res, 'code_too_long', 400, { max: 20 })
+
+      // 4. if changing code — check duplicate under same parent
       if (code && code !== node.code) {
         const duplicate = await prisma.propertyNode.findFirst({
           where: {

--- a/apps/api/src/routes/societies.ts
+++ b/apps/api/src/routes/societies.ts
@@ -37,7 +37,14 @@ router.post('/', authenticate, async (req: AuthRequest, res: Response) => {
       })
     }
 
-    // 2. Validate type enum
+    // 2. Validate lengths and formats
+    if (name.length > 100) return sendError(res, 'name_too_long', 400, { max: 100 })
+    if (address.length > 200) return sendError(res, 'address_too_long', 400, { max: 200 })
+    if (city.length > 100) return sendError(res, 'city_too_long', 400, { max: 100 })
+    if (state.length > 100) return sendError(res, 'state_too_long', 400, { max: 100 })
+    if (!/^\d{6}$/.test(pincode)) return sendError(res, 'invalid_pincode', 400, { message: 'Pincode must be exactly 6 digits' })
+
+    // 3. Validate type enum
     if (!VALID_TYPES.includes(type)) {
       return sendError(res, 'invalid_type', 400, {
         allowed: VALID_TYPES
@@ -351,8 +358,20 @@ router.patch(
       if (contactPhone && typeof contactPhone !== 'string') {
         return sendError(res, 'invalid_phone', 400, {})
       }
+      if (contactPhone && !/^\+?[\d\s\-]{7,15}$/.test(contactPhone)) {
+        return sendError(res, 'invalid_phone', 400, { message: 'Invalid phone format' })
+      }
+      if (contactPhone && contactPhone.length > 15) {
+        return sendError(res, 'invalid_phone', 400, { message: 'Phone max 15 characters' })
+      }
       if (contactEmail && typeof contactEmail !== 'string') {
         return sendError(res, 'invalid_email', 400, {})
+      }
+      if (contactEmail && contactEmail.length > 100) {
+        return sendError(res, 'invalid_email', 400, { message: 'Email max 100 characters' })
+      }
+      if (contactEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(contactEmail)) {
+        return sendError(res, 'invalid_email', 400, { message: 'Invalid email format' })
       }
       if (description && typeof description !== 'string') {
         return sendError(res, 'invalid_description', 400, {})

--- a/apps/api/src/routes/units.ts
+++ b/apps/api/src/routes/units.ts
@@ -302,28 +302,33 @@ router.post(
       }
 
       // Create ownership record
-      const ownership = await prisma.unitOwnership.create({
-        data: {
-          orgId,
-          unitId: nodeId,
-          personId: person.id,
-          ownershipType,
-          isPrimary,
-          ownedFrom: new Date()
-        }
-      })
+      try {
+        const ownership = await prisma.unitOwnership.create({
+          data: {
+            orgId,
+            unitId: nodeId,
+            personId: person.id,
+            ownershipType,
+            isPrimary,
+            ownedFrom: new Date()
+          }
+        })
 
-      return sendSuccess(res, {
-        id: ownership.id,
-        flatName: unit.name,
-        member: {
-          name: person.fullName,
-          phone: person.phone
-        },
-        ownershipType: ownership.ownershipType,
-        isPrimary: ownership.isPrimary,
-        ownedFrom: ownership.ownedFrom
-      }, 201)
+        return sendSuccess(res, {
+          id: ownership.id,
+          flatName: unit.name,
+          member: {
+            name: person.fullName,
+            phone: person.phone
+          },
+          ownershipType: ownership.ownershipType,
+          isPrimary: ownership.isPrimary,
+          ownedFrom: ownership.ownedFrom
+        }, 201)
+      } catch (e: any) {
+        if (e.code === 'P2002') return sendError(res, 'primary_owner_exists', 409, { message: 'A primary owner already exists for this unit' })
+        throw e
+      }
 
     } catch (error) {
       console.error('POST /ownership error:', error)
@@ -428,27 +433,32 @@ router.post(
         return sendError(res, 'already_occupying', 400)
       }
 
-      const occupancy = await prisma.unitOccupancy.create({
-        data: {
-          unitId: nodeId,
-          personId: person.id,
-          occupancyType,
-          isPrimary,
-          occupiedFrom: new Date()
-        }
-      })
+      try {
+        const occupancy = await prisma.unitOccupancy.create({
+          data: {
+            unitId: nodeId,
+            personId: person.id,
+            occupancyType,
+            isPrimary,
+            occupiedFrom: new Date()
+          }
+        })
 
-      return sendSuccess(res, {
-        id: occupancy.id,
-        flatName: unit.name,
-        member: {
-          name: person.fullName,
-          phone: person.phone
-        },
-        occupancyType: occupancy.occupancyType,
-        isPrimary: occupancy.isPrimary,
-        occupiedFrom: occupancy.occupiedFrom
-      }, 201)
+        return sendSuccess(res, {
+          id: occupancy.id,
+          flatName: unit.name,
+          member: {
+            name: person.fullName,
+            phone: person.phone
+          },
+          occupancyType: occupancy.occupancyType,
+          isPrimary: occupancy.isPrimary,
+          occupiedFrom: occupancy.occupiedFrom
+        }, 201)
+      } catch (e: any) {
+        if (e.code === 'P2002') return sendError(res, 'primary_occupant_exists', 409, { message: 'A primary occupant already exists for this unit' })
+        throw e
+      }
 
     } catch (error) {
       console.error('POST /occupancy error:', error)

--- a/apps/api/src/routes/visitors.ts
+++ b/apps/api/src/routes/visitors.ts
@@ -139,6 +139,8 @@ router.post(
         })
       }
 
+      if (name.length > 100) return sendError(res, 'name_too_long', 400, { max: 100 })
+
       const validTypes = ['INDIVIDUAL', 'DELIVERY', 'SERVICE', 'DOMESTIC', 'CAB', 'OTHER']
       if (!validTypes.includes(type)) {
         return sendError(res, 'invalid_type', 400)
@@ -779,6 +781,9 @@ router.post(
       if (!visitorName || !unitId) {
         return sendError(res, 'missing_field', 400)
       }
+
+      if (visitorName.length > 100) return sendError(res, 'name_too_long', 400, { max: 100 })
+      if (note && note.length > 500) return sendError(res, 'note_too_long', 400, { max: 500 })
 
       if (expiresAt) {
         const parsed = new Date(expiresAt)

--- a/apps/api/tests/members.test.ts
+++ b/apps/api/tests/members.test.ts
@@ -211,13 +211,21 @@ describe('Members', () => {
       where: { user: { phone: '+919222222222' } }
     })
     if (person) {
-      await prisma.unitOccupancy.updateMany({
-        where: {
-          personId: person.id,
-          occupiedUntil: { not: null }
-        },
-        data: { occupiedUntil: null }
+      const hasActive = await prisma.unitOccupancy.findFirst({
+        where: { personId: person.id, occupiedUntil: null }
       })
+      if (!hasActive) {
+        const lastEnded = await prisma.unitOccupancy.findFirst({
+          where: { personId: person.id, occupiedUntil: { not: null } },
+          orderBy: { occupiedUntil: 'desc' }
+        })
+        if (lastEnded) {
+          await prisma.unitOccupancy.update({
+            where: { id: lastEnded.id },
+            data: { occupiedUntil: null }
+          })
+        }
+      }
     }
   })
 })


### PR DESCRIPTION
## Security Fixes — Sprint 2

### Architecture & Data Integrity
- Partial unique indexes on unit_ownerships and unit_occupancies
  — prevents two concurrent requests from both becoming
  primary owner/occupant of the same unit (H1)
- Unique constraint on property_nodes (orgId, parentId, code)
  — prevents duplicate node codes in same parent (H2)
- P2002 constraint violations handled gracefully with
  clear error messages

### Transaction Safety
- Invitation accept now atomic — membership creation and
  invitation update in single transaction (M3)

### Security
- Request body limit reduced from 50mb to 10mb (H5)

### Input Validation
- Society: name≤100, address≤200, pincode must be 6 digits
- Society settings: phone format, email format, max lengths
- Complaints: title≤200, description≤5000
- Announcements: title≤200, body≤10000
- Visitors: name≤100, note≤500
- Nodes: name≤100, code≤20

### Tests
310 passing
2 migrations applied to production (Neon)